### PR TITLE
Don't require a semicolon or line-break after the last statement in a block/program

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -34,7 +34,18 @@ module.exports = grammar({
   ],
 
   rules: {
-    program: $ => repeat($._statement),
+    program: $ => optional($._statements),
+
+    _statements: $ => choice(
+      seq($._statement, optional($._statements)),
+      choice(
+        $.trailing_break_statement,
+        $.trailing_yield_statement,
+        $.trailing_throw_statement,
+        $.trailing_return_statement,
+        $.trailing_expression_statement
+      )
+    ),
 
     //
     // Statements
@@ -64,6 +75,10 @@ module.exports = grammar({
       err(choice($._expression, $.comma_op)), terminator()
     ),
 
+    trailing_expression_statement: $ => seq(
+      choice($._expression, $.comma_op)
+    ),
+
     var_declaration: $ => seq(
       variableType(),
       commaSep1(err(choice(
@@ -74,7 +89,7 @@ module.exports = grammar({
     ),
 
     statement_block: $ => seq(
-      '{', err(repeat($._statement)), '}'
+      '{', err(optional($._statements)), '}'
     ),
 
     if_statement: $ => prec.right(seq(
@@ -155,10 +170,17 @@ module.exports = grammar({
       terminator()
     ),
 
+    trailing_break_statement: $ => 'break',
+
     return_statement: $ => seq(
       'return',
       optional($._expression),
       terminator()
+    ),
+
+    trailing_return_statement: $ => seq(
+      'return',
+      optional($._expression)
     ),
 
     yield_statement: $ => seq(
@@ -167,10 +189,20 @@ module.exports = grammar({
       terminator()
     ),
 
+    trailing_yield_statement: $ => seq(
+      'yield',
+      optional($._expression)
+    ),
+
     throw_statement: $ => seq(
       'throw',
       $._expression,
       terminator()
+    ),
+
+    trailing_throw_statement: $ => seq(
+      'throw',
+      $._expression
     ),
 
     //
@@ -181,13 +213,13 @@ module.exports = grammar({
       'case',
       $._expression,
       ':',
-      repeat($._statement)
+      optional($._statements)
     ),
 
     default: $ => seq(
       'default',
       ':',
-      repeat($._statement)
+      optional($._statements)
     ),
 
     catch: $ => seq(

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -26,3 +26,20 @@ indented code after blocks
   (expression_statement
     (function (identifier) (statement_block)))
   (return_statement (identifier)))
+
+===========================================
+single-line blocks without semicolons
+===========================================
+
+function a() {b}
+function c() {return d}
+
+---
+
+(program
+  (expression_statement
+    (function (identifier) (statement_block
+      (trailing_expression_statement (identifier)))))
+  (expression_statement
+    (function (identifier) (statement_block
+      (trailing_return_statement (identifier))))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2,11 +2,67 @@
   "name": "javascript",
   "rules": {
     "program": {
-      "type": "REPEAT",
-      "content": {
-        "type": "SYMBOL",
-        "name": "_statement"
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_statements"
+        },
+        {
+          "type": "BLANK"
+        }
+      ]
+    },
+    "_statements": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statement"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "trailing_break_statement"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "trailing_yield_statement"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "trailing_throw_statement"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "trailing_return_statement"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "trailing_expression_statement"
+            }
+          ]
+        }
+      ]
     },
     "_statement": {
       "type": "CHOICE",
@@ -107,6 +163,24 @@
         }
       ]
     },
+    "trailing_expression_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "comma_op"
+            }
+          ]
+        }
+      ]
+    },
     "var_declaration": {
       "type": "SEQ",
       "members": [
@@ -201,11 +275,16 @@
         {
           "type": "ERROR",
           "content": {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_statement"
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_statements"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         },
         {
@@ -632,6 +711,10 @@
         }
       ]
     },
+    "trailing_break_statement": {
+      "type": "STRING",
+      "value": "break"
+    },
     "return_statement": {
       "type": "SEQ",
       "members": [
@@ -661,6 +744,27 @@
             {
               "type": "SYMBOL",
               "name": "_line_break"
+            }
+          ]
+        }
+      ]
+    },
+    "trailing_return_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "BLANK"
             }
           ]
         }
@@ -700,6 +804,27 @@
         }
       ]
     },
+    "trailing_yield_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "yield"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
     "throw_statement": {
       "type": "SEQ",
       "members": [
@@ -726,6 +851,19 @@
         }
       ]
     },
+    "trailing_throw_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "throw"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        }
+      ]
+    },
     "case": {
       "type": "SEQ",
       "members": [
@@ -742,11 +880,16 @@
           "value": ":"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -762,11 +905,16 @@
           "value": ":"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Refs #8 

This solves the optional semicolon problem in a different way than @robrix [used](https://github.com/tree-sitter/tree-sitter-ruby/blob/ce1cc836dfaf21d0e8d44ed58c49780f1d53b9ff/grammar.js#L49) in the ruby grammar. Rob treated the `;` as a separator *between* statements, rather than treating it as *part* of the statement. 

What I did instead was to make it explicit that the *last* statement in a block is not required to end with a `;` or a `\n`. So the expression statement with no `;` in @joshvera's unit test parses as a `trailing_expression_statement`.

Rob's solution is more elegant, and in the case of ruby, better in every way. But optional semicolons are a little hairier in javascript than in ruby, because javascript allows code like this:

```js
foo      // <--- not the end of a statement
  .bar
  .baz;
```

Basically, in order to tell whether or not the first line-break functions as a terminator, you have to look forward to the next token. Ruby and Go (and I think Rust) disallow this, but in JS, it's super common 😬.

Unfortunately, tree-sitter isn't yet smart enough to handle code like the example above if we use Rob's technique. The notion of having tokens like `\n` that can either be syntactically meaningful or function as whitespace is something that I kind of made up for tree-sitter, rather than basing it on some established method. I tried to make it Just Work™, but it's not fully baked 😢.

In the meantime, do you think this solution will suffice?