### PR TITLE
Add destructuring in assignments, var declarations, function parameters

### DIFF
--- a/grammar_test/destructuring.txt
+++ b/grammar_test/destructuring.txt
@@ -1,0 +1,69 @@
+============================================
+Object destructuring assignments
+============================================
+
+{a, b} = object
+let {a, b, ...c} = object
+const {a, b: {c, d}} = object
+
+---
+
+(program
+  (expression_statement (assignment
+    (object_assignment_pattern
+      (identifier)
+      (identifier))
+    (identifier)))
+  (var_declaration (var_assignment
+    (object_assignment_pattern
+      (identifier)
+      (identifier)
+      (assignment_rest_element (identifier)))
+    (identifier)))
+  (var_declaration (var_assignment
+    (object_assignment_pattern
+      (identifier)
+      (assignment_property
+        (identifier)
+        (object_assignment_pattern
+          (identifier)
+          (identifier))))
+    (identifier))))
+
+============================================
+Object destructuring parameters
+============================================
+
+function a ({b, c}, {d}) {}
+
+---
+
+(program
+  (expression_statement
+    (function (identifier)
+      (formal_parameters
+        (object_assignment_pattern (identifier) (identifier))
+        (object_assignment_pattern (identifier)))
+      (statement_block))))
+
+============================================
+Array destructuring assignments
+============================================
+
+[a, b] = array
+[a, b, ...c] = array
+
+---
+
+(program
+  (expression_statement (assignment
+    (array_assignment_pattern
+      (identifier)
+      (identifier))
+    (identifier)))
+  (expression_statement (assignment
+    (array_assignment_pattern
+      (identifier)
+      (identifier)
+      (assignment_rest_element (identifier)))
+    (identifier))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1435,7 +1435,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_assignment_pattern"
         },
         {
           "type": "STRING",
@@ -2109,15 +2109,15 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "member_access"
               },
               {
                 "type": "SYMBOL",
                 "name": "subscript_access"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_assignment_pattern"
               }
             ]
           },
@@ -2182,6 +2182,173 @@
           }
         ]
       }
+    },
+    "_assignment_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "object_assignment_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_assignment_pattern"
+        }
+      ]
+    },
+    "object_assignment_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "assignment_property"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "assignment_rest_element"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "assignment_property"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "assignment_rest_element"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "array_assignment_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_assignment_pattern"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "assignment_rest_element"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_assignment_pattern"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "assignment_rest_element"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "assignment_property": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_assignment_pattern"
+        }
+      ]
+    },
+    "assignment_rest_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "..."
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
     },
     "ternary": {
       "type": "PREC_RIGHT",
@@ -3292,8 +3459,17 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "object_assignment_pattern"
+            }
+          ]
         },
         {
           "type": "REPEAT",
@@ -3305,8 +3481,17 @@
                 "value": ","
               },
               {
-                "type": "SYMBOL",
-                "name": "identifier"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "object_assignment_pattern"
+                  }
+                ]
               }
             ]
           }
@@ -3461,6 +3646,18 @@
     [
       "_expression",
       "formal_parameters"
+    ],
+    [
+      "_expression",
+      "object_assignment_pattern"
+    ],
+    [
+      "_expression",
+      "_assignment_pattern"
+    ],
+    [
+      "_expression",
+      "array_assignment_pattern"
     ]
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-javascript/issues/22

See http://www.ecma-international.org/ecma-262/6.0/#sec-destructuring-assignment

I don't fully understand the productions containing 'initializer' in the es6 spec, and I haven't seen examples of that, so I'm going to hold off on modeling that for now. I think this will prevent another big set of errors when parsing ES6 files.

/cc @joshvera