### PR TITLE
Support multiple function declarations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,5 +1,6 @@
 const PREC = {
   COMMA: -1,
+  DECLARATION: 1,
   ASSIGN: 0,
   OBJECT: 1,
   TERNARY: 1,
@@ -82,13 +83,12 @@ module.exports = grammar({
     ),
 
     // A function, generator, class, or variable declaration
-    _declaration: $ => choice(
+    _declaration: $ => prec(PREC.DECLARATION, choice(
       $.function,
       $.generator_function,
-      $.anonymous_class,
       $.class,
       $.var_declaration
-    ),
+    )),
 
     //
     // Import declarations
@@ -136,7 +136,7 @@ module.exports = grammar({
       $.export_statement,
       $.import_statement,
       $.expression_statement,
-      $.var_declaration,
+      $._declaration,
       $.statement_block,
 
       $.if_statement,
@@ -179,11 +179,6 @@ module.exports = grammar({
     _statements: $ => choice(
       seq($._statement, optional($._statements)),
       $._trailing_statement
-    ),
-
-    _functions: $ => seq(
-      $.function,
-      optional($._functions)
     ),
 
     trailing_expression_statement: $ => seq(
@@ -447,7 +442,7 @@ module.exports = grammar({
       $.object,
       $.array,
       $.class,
-      $._functions,
+      $.function,
       $.arrow_function,
       $.generator_function,
       $.function_call,
@@ -550,7 +545,7 @@ module.exports = grammar({
     ),
 
     function_call: $ => prec(PREC.CALL, seq(
-      choice($._expression, $.super),
+      choice($._expression, $.super, $.function),
       $.arguments
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -590,7 +590,7 @@ module.exports = grammar({
         $.member_access,
         $.subscript_access
       ),
-      choice('+=', '-=', '*=', '/='),
+      choice('+=', '-=', '*=', '/=', '^='),
       $._expression
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -158,6 +158,7 @@ module.exports = grammar({
 
     _trailing_statement: $ => choice(
       $.trailing_break_statement,
+      $.trailing_continue_statement,
       $.trailing_yield_statement,
       $.trailing_throw_statement,
       $.trailing_return_statement,
@@ -351,12 +352,14 @@ module.exports = grammar({
       terminator()
     ),
 
+    trailing_break_statement: $ => 'break',
+
     continue_statement: $ => seq(
       'continue',
       terminator()
     ),
 
-    trailing_break_statement: $ => 'break',
+    trailing_continue_statement: $ => 'continue',
 
     return_statement: $ => seq(
       'return',

--- a/grammar.js
+++ b/grammar.js
@@ -176,6 +176,16 @@ module.exports = grammar({
       terminator()
     ),
 
+    _statements: $ => choice(
+      seq($._statement, optional($._statements)),
+      $._trailing_statement
+    ),
+
+    _functions: $ => seq(
+      $.function,
+      optional($._functions)
+    ),
+
     trailing_expression_statement: $ => seq(
       choice($._expression, $.comma_op)
     ),
@@ -437,7 +447,7 @@ module.exports = grammar({
       $.object,
       $.array,
       $.class,
-      $.function,
+      $._functions,
       $.arrow_function,
       $.generator_function,
       $.function_call,

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -281,26 +281,29 @@ Arrays
 Functions
 ============================================
 
-function() {};
-function(arg1, arg2) {
-  arg2;
-};
-function stuff() {}
+[
+  function() {},
+  function(arg1, arg2) {
+    arg2;
+  },
+  function stuff() {}
+]
 
 ---
 
 (program
-  (expression_statement (function
-    (formal_parameters)
-    (statement_block)))
-  (expression_statement (function
-    (formal_parameters (identifier) (identifier))
-    (statement_block
-      (expression_statement (identifier)))))
-  (expression_statement (function
-    (identifier)
-    (formal_parameters)
-    (statement_block))))
+  (expression_statement (array
+    (function
+      (formal_parameters)
+      (statement_block))
+    (function
+      (formal_parameters (identifier) (identifier))
+      (statement_block
+        (expression_statement (identifier))))
+    (function
+      (identifier)
+      (formal_parameters)
+      (statement_block)))))
 
 ===================================================
 Arrow functions
@@ -334,24 +337,27 @@ a => 1;
 Generator Functions
 ============================================
 
-function *() {};
-function *generateStuff(arg1, arg2) {
-  yield;
-  yield arg2;
-};
+[
+  function *() {},
+  function *generateStuff(arg1, arg2) {
+    yield;
+    yield arg2;
+  }
+]
 
 ---
 
 (program
-  (expression_statement (generator_function
-    (formal_parameters)
-    (statement_block)))
-  (expression_statement (generator_function
-    (identifier)
-    (formal_parameters (identifier) (identifier))
-    (statement_block
-      (yield_statement)
-      (yield_statement (identifier))))))
+  (expression_statement (array
+    (generator_function
+      (formal_parameters)
+      (statement_block))
+    (generator_function
+      (identifier)
+      (formal_parameters (identifier) (identifier))
+      (statement_block
+        (yield_statement)
+        (yield_statement (identifier)))))))
 
 ============================================
 Property access

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -717,12 +717,15 @@ a = void b()
 Math assignment operators
 ==============================================
 
-x += 1;
+w ^= 1;
+x += 2;
 y.z *= 3;
 
 ---
 
 (program
+  (expression_statement
+    (math_assignment (identifier) (number)))
   (expression_statement
     (math_assignment (identifier) (number)))
   (expression_statement

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -61,7 +61,8 @@ function c() {return d}
 (program
   (expression_statement
     (function (identifier) (formal_parameters) (statement_block
-      (trailing_expression_statement (identifier))))
+      (trailing_expression_statement (identifier)))))
+  (expression_statement
     (function (identifier) (formal_parameters) (statement_block
       (trailing_return_statement (identifier))))))
 
@@ -126,17 +127,16 @@ if (p) { var q }
   (if_statement (identifier) (statement_block
     (trailing_var_declaration (identifier)))))
 
-==============================================
-multiple function declarations
-==============================================
+=====================================================
+Single-line declarations without semicolons
+=====================================================
 
-function i () { return true; } function j () { return false; }
-
+function a () { function b () {} function *c () {} class D {} return }
 ---
 
 (program
-  (expression_statement
-    (function (identifier) (formal_parameters)
-      (statement_block (return_statement (true))))
-    (function (identifier) (formal_parameters)
-      (statement_block (return_statement (false))))))
+  (function (identifier) (formal_parameters) (statement_block
+    (function (identifier) (formal_parameters) (statement_block))
+    (generator_function (identifier) (formal_parameters) (statement_block))
+    (class (identifier) (class_body))
+    (trailing_return_statement))))

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -126,3 +126,18 @@ if (p) { var q }
       (identifier))))
   (if_statement (identifier) (statement_block
     (trailing_var_declaration (identifier)))))
+
+==============================================
+multiple function declarations
+==============================================
+
+function i () { return true; } function j () { return false; }
+
+---
+
+(program
+  (expression_statement
+    (function (identifier) (formal_parameters)
+      (statement_block (return_statement (true))))
+    (function (identifier) (formal_parameters)
+      (statement_block (return_statement (false))))))

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -61,8 +61,7 @@ function c() {return d}
 (program
   (expression_statement
     (function (identifier) (formal_parameters) (statement_block
-      (trailing_expression_statement (identifier)))))
-  (expression_statement
+      (trailing_expression_statement (identifier))))
     (function (identifier) (formal_parameters) (statement_block
       (trailing_return_statement (identifier))))))
 

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -96,7 +96,7 @@ if/for/while/do statements without semicolons
 if (a) { if (b) return c }
 if (d) { for (;;) break }
 if (e) { for (f in g) break }
-if (h) { for (i of j) break }
+if (h) { for (i of j) continue }
 if (k) { while (l) break }
 if (m) { do { n; } while (o) }
 if (p) { var q }
@@ -116,7 +116,7 @@ if (p) { var q }
       (trailing_break_statement))))
   (if_statement (identifier) (statement_block
     (trailing_for_of_statement (identifier) (identifier)
-      (trailing_break_statement))))
+      (trailing_continue_statement))))
   (if_statement (identifier) (statement_block
     (trailing_while_statement (identifier)
       (trailing_break_statement))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -267,29 +267,29 @@
       ]
     },
     "_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "function"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "generator_function"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "anonymous_class"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "class"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "var_declaration"
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "function"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "generator_function"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "class"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "var_declaration"
+          }
+        ]
+      }
     },
     "import_statement": {
       "type": "SEQ",
@@ -505,7 +505,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "var_declaration"
+          "name": "_declaration"
         },
         {
           "type": "SYMBOL",
@@ -648,27 +648,6 @@
             {
               "type": "SYMBOL",
               "name": "_line_break"
-            }
-          ]
-        }
-      ]
-    },
-    "_functions": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "function"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_functions"
-            },
-            {
-              "type": "BLANK"
             }
           ]
         }
@@ -1933,6 +1912,94 @@
         }
       ]
     },
+    "function": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "async"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "function"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "formal_parameters"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "statement_block"
+        }
+      ]
+    },
+    "arrow_function": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "async"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "formal_parameters"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "statement_block"
+            }
+          ]
+        }
+      ]
+    },
     "_expression": {
       "type": "CHOICE",
       "members": [
@@ -1950,7 +2017,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_functions"
+          "name": "function"
         },
         {
           "type": "SYMBOL",
@@ -2291,94 +2358,6 @@
         }
       ]
     },
-    "function": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "async"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "function"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "formal_parameters"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "statement_block"
-        }
-      ]
-    },
-    "arrow_function": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "async"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "formal_parameters"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "=>"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "statement_block"
-            }
-          ]
-        }
-      ]
-    },
     "generator_function": {
       "type": "SEQ",
       "members": [
@@ -2428,6 +2407,10 @@
               {
                 "type": "SYMBOL",
                 "name": "super"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function"
               }
             ]
           },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -653,6 +653,27 @@
         }
       ]
     },
+    "_functions": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "function"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_functions"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
     "trailing_expression_statement": {
       "type": "SEQ",
       "members": [
@@ -1929,7 +1950,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "function"
+          "name": "_functions"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -578,6 +578,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "trailing_continue_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "trailing_yield_statement"
         },
         {
@@ -1558,6 +1562,10 @@
         }
       ]
     },
+    "trailing_break_statement": {
+      "type": "STRING",
+      "value": "break"
+    },
     "continue_statement": {
       "type": "SEQ",
       "members": [
@@ -1580,9 +1588,9 @@
         }
       ]
     },
-    "trailing_break_statement": {
+    "trailing_continue_statement": {
       "type": "STRING",
-      "value": "break"
+      "value": "continue"
     },
     "return_statement": {
       "type": "SEQ",
@@ -1909,94 +1917,6 @@
         {
           "type": "STRING",
           "value": ")"
-        }
-      ]
-    },
-    "function": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "async"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "function"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "formal_parameters"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "statement_block"
-        }
-      ]
-    },
-    "arrow_function": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "async"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "formal_parameters"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "=>"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "statement_block"
-            }
-          ]
         }
       ]
     },
@@ -2358,6 +2278,94 @@
         }
       ]
     },
+    "function": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "async"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "function"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "formal_parameters"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "statement_block"
+        }
+      ]
+    },
+    "arrow_function": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "async"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "formal_parameters"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "statement_block"
+            }
+          ]
+        }
+      ]
+    },
     "generator_function": {
       "type": "SEQ",
       "members": [
@@ -2576,6 +2584,10 @@
               {
                 "type": "STRING",
                 "value": "/="
+              },
+              {
+                "type": "STRING",
+                "value": "^="
               }
             ]
           },


### PR DESCRIPTION
Our ability to parse multiple functions defined inline was problematic.

e.g.:

```javascript
function test(){function one(){}function two(){}function three(){}}
```

This patch makes it possible to parse multiple inline functions, although it does impact the way `expression_statement` parses `function`. Previously, every function was parsed as an individual `expression_statement`, but now, multiple sequential functions are defined as a single `expression_statement`. This approach may not be tenable, but figure it is a good place to get the ball rolling towards a solution.

/cc @maxbrunsfeld @tclem @joshvera 