### PR TITLE
Parse JSX

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -444,6 +444,8 @@ module.exports = grammar({
     _expression: $ => choice(
       $.object,
       $.array,
+      $.jsx_element,
+      $.jsx_self_closing_element,
       $.class,
       $.function,
       $.arrow_function,
@@ -493,6 +495,42 @@ module.exports = grammar({
 
     array: $ => seq(
       '[', optional($._element_list), ']'
+    ),
+
+    jsx_element: $ => seq(
+      $.jsx_opening_element,
+      $.jsx_closing_element
+    ),
+
+    jsx_opening_element: $ => seq(
+      '<',
+      $.identifier,
+      repeat($.jsx_attribute),
+      '>'
+    ),
+
+    jsx_closing_element: $ => seq(
+      '<',
+      '/',
+      $.identifier,
+      '>'
+    ),
+
+    jsx_self_closing_element: $ => seq(
+      '<',
+      $.identifier,
+      repeat($.jsx_attribute),
+      '/',
+      '>'
+    ),
+
+    jsx_attribute: $ => seq(
+      $.identifier,
+      '=',
+      choice(
+        $.number,
+        $.string
+      )
     ),
 
     _element_list: $ => commaSep1Trailing($._element_list, choice(

--- a/grammar.js
+++ b/grammar.js
@@ -540,11 +540,14 @@ module.exports = grammar({
 
     jsx_attribute: $ => seq(
       $.identifier,
-      '=',
-      choice(
-        $.number,
-        $.string
-      )
+      optional(seq(
+        '=',
+        choice(
+          $.number,
+          $.string,
+          $.jsx_expression
+        )
+      ))
     ),
 
     _element_list: $ => commaSep1Trailing($._element_list, choice(

--- a/grammar.js
+++ b/grammar.js
@@ -512,7 +512,7 @@ module.exports = grammar({
 
     jsx_expression: $ => seq(
       '{',
-      choice($._expression, $.comma_op),
+      choice($._expression, $.comma_op, $.spread_element),
       '}'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -499,7 +499,21 @@ module.exports = grammar({
 
     jsx_element: $ => seq(
       $.jsx_opening_element,
+      repeat(choice(
+        $.jsx_element,
+        $.jsx_self_closing_element,
+        $.jsx_expression,
+        $.jsx_text
+      )),
       $.jsx_closing_element
+    ),
+
+    jsx_text: $ => /[^{}<>]+/,
+
+    jsx_expression: $ => seq(
+      '{',
+      choice($._expression, $.comma_op),
+      '}'
     ),
 
     jsx_opening_element: $ => seq(

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -765,3 +765,26 @@ typeof a == b && c instanceof d
       (type_op (identifier))
       (identifier))
     (type_op (identifier) (identifier)))))
+
+==============================================
+JSX literals
+==============================================
+
+a = <div className='b' tabIndex=1 />;
+b = <div>
+</div>
+
+---
+
+(program
+  (expression_statement (assignment
+    (identifier)
+    (jsx_self_closing_element
+      (identifier)
+      (jsx_attribute (identifier) (string))
+      (jsx_attribute (identifier) (number)))))
+  (expression_statement (assignment
+    (identifier)
+    (jsx_element
+      (jsx_opening_element (identifier))
+      (jsx_closing_element (identifier))))))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -767,12 +767,11 @@ typeof a == b && c instanceof d
     (type_op (identifier) (identifier)))))
 
 ==============================================
-JSX literals
+Simple JSX elements
 ==============================================
 
 a = <div className='b' tabIndex=1 />;
-b = <div>Stuff</div>;
-c = <a>b {c} <img/></a>
+b = <div>a <span>b</span> c</div>;
 
 ---
 
@@ -788,13 +787,29 @@ c = <a>b {c} <img/></a>
     (jsx_element
       (jsx_opening_element (identifier))
       (jsx_text)
-      (jsx_closing_element (identifier)))))
+      (jsx_element
+        (jsx_opening_element (identifier))
+        (jsx_text)
+        (jsx_closing_element (identifier)))
+      (jsx_text)
+      (jsx_closing_element (identifier))))))
+
+==============================================
+Expressions within JSX elements
+==============================================
+
+c = <a b c={d}> e {f} g </a>
+
+---
+
+(program
   (expression_statement (assignment
     (identifier)
     (jsx_element
-      (jsx_opening_element (identifier))
+      (jsx_opening_element (identifier)
+        (jsx_attribute (identifier))
+        (jsx_attribute (identifier) (jsx_expression (identifier))))
       (jsx_text)
       (jsx_expression (identifier))
       (jsx_text)
-      (jsx_self_closing_element (identifier))
       (jsx_closing_element (identifier))))))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -798,7 +798,8 @@ b = <div>a <span>b</span> c</div>;
 Expressions within JSX elements
 ==============================================
 
-c = <a b c={d}> e {f} g </a>
+a = <a b c={d}> e {f} g </a>
+h = <i>{...j}</i>
 
 ---
 
@@ -812,4 +813,10 @@ c = <a b c={d}> e {f} g </a>
       (jsx_text)
       (jsx_expression (identifier))
       (jsx_text)
+      (jsx_closing_element (identifier)))))
+  (expression_statement (assignment
+    (identifier)
+    (jsx_element
+      (jsx_opening_element (identifier))
+      (jsx_expression (spread_element (identifier)))
       (jsx_closing_element (identifier))))))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -771,8 +771,8 @@ JSX literals
 ==============================================
 
 a = <div className='b' tabIndex=1 />;
-b = <div>
-</div>
+b = <div>Stuff</div>;
+c = <a>b {c} <img/></a>
 
 ---
 
@@ -787,4 +787,14 @@ b = <div>
     (identifier)
     (jsx_element
       (jsx_opening_element (identifier))
+      (jsx_text)
+      (jsx_closing_element (identifier)))))
+  (expression_statement (assignment
+    (identifier)
+    (jsx_element
+      (jsx_opening_element (identifier))
+      (jsx_text)
+      (jsx_expression (identifier))
+      (jsx_text)
+      (jsx_self_closing_element (identifier))
       (jsx_closing_element (identifier))))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2232,6 +2232,10 @@
             {
               "type": "SYMBOL",
               "name": "comma_op"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "spread_element"
             }
           ]
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2182,8 +2182,62 @@
           "name": "jsx_opening_element"
         },
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "jsx_element"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "jsx_self_closing_element"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "jsx_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "jsx_text"
+              }
+            ]
+          }
+        },
+        {
           "type": "SYMBOL",
           "name": "jsx_closing_element"
+        }
+      ]
+    },
+    "jsx_text": {
+      "type": "PATTERN",
+      "value": "[^{}<>]+"
+    },
+    "jsx_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "comma_op"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1933,6 +1933,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "jsx_element"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "jsx_self_closing_element"
+        },
+        {
+          "type": "SYMBOL",
           "name": "class"
         },
         {
@@ -2163,6 +2171,118 @@
         {
           "type": "STRING",
           "value": "]"
+        }
+      ]
+    },
+    "jsx_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "jsx_opening_element"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "jsx_closing_element"
+        }
+      ]
+    },
+    "jsx_opening_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "jsx_attribute"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "jsx_closing_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "STRING",
+          "value": "/"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "jsx_self_closing_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "jsx_attribute"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "/"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "jsx_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2322,19 +2322,36 @@
           "name": "identifier"
         },
         {
-          "type": "STRING",
-          "value": "="
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "number"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "number"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "string"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "jsx_expression"
+                    }
+                  ]
+                }
+              ]
             },
             {
-              "type": "SYMBOL",
-              "name": "string"
+              "type": "BLANK"
             }
           ]
         }


### PR DESCRIPTION
JSX is often used in files [like this](https://github.com/facebook/react/blob/master/src/test/__tests__/ReactTestUtils-test.js), that have no special `jsx` extension, so I think this grammar needs to handle JSX.

Based on the official grammar:
https://facebook.github.io/jsx