### PR TITLE
Restructure some rules to allow typescript to extend this grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -45,7 +45,7 @@ module.exports = grammar({
     // ( foo
     // ( foo
     //    ^-- arrow function parameter or parenthesized expression?
-    [$._formal_parameter, $._expression],
+    [$._pattern, $._expression],
 
     // ( {foo} )
     // ( [foo] )
@@ -92,7 +92,7 @@ module.exports = grammar({
       $.function,
       $.generator_function,
       $.class,
-      $.var_declaration
+      $.variable_declaration
     )),
 
     //
@@ -174,7 +174,7 @@ module.exports = grammar({
       $.trailing_for_of_statement,
       $.trailing_while_statement,
       $.trailing_do_statement,
-      $.trailing_var_declaration
+      $.trailing_variable_declaration
     ),
 
     expression_statement: $ => seq(
@@ -191,22 +191,22 @@ module.exports = grammar({
       choice($._expression, $.comma_op)
     ),
 
-    var_declaration: $ => seq(
+    variable_declaration: $ => seq(
       variableType(),
-      commaSep1(choice(
-        $.identifier,
-        $.assignment_pattern,
-        $.var_assignment
-      )),
+      commaSep1($.variable_declarator),
       terminator()
     ),
 
-    trailing_var_declaration: $ => seq(
+    trailing_variable_declaration: $ => seq(
       variableType(),
-      commaSep1(choice(
-        $.identifier,
-        $.assignment_pattern,
-        $.var_assignment
+      commaSep1($.variable_declarator)
+    ),
+
+    variable_declarator: $ => seq(
+      $._pattern,
+      optional(seq(
+        '=',
+        $._expression
       ))
     ),
 
@@ -250,7 +250,7 @@ module.exports = grammar({
       'for',
       '(',
       choice(
-        $.var_declaration,
+        $.variable_declaration,
         seq(commaSep1($._expression), ';'),
         ';'
       ),
@@ -264,7 +264,7 @@ module.exports = grammar({
       'for',
       '(',
       choice(
-        $.var_declaration,
+        $.variable_declaration,
         seq(commaSep1($._expression), ';'),
         ';'
       ),
@@ -427,15 +427,6 @@ module.exports = grammar({
     finally: $ => seq(
       'finally',
       $.statement_block
-    ),
-
-    var_assignment: $ => seq(
-      choice(
-        $.assignment_pattern,
-        $.identifier
-      ),
-      '=',
-      $._expression
     ),
 
     _paren_expression: $ => seq(
@@ -637,8 +628,7 @@ module.exports = grammar({
       choice(
         $.member_access,
         $.subscript_access,
-        $.identifier,
-        $.assignment_pattern
+        $._pattern
       ),
       '=',
       $._expression
@@ -653,6 +643,11 @@ module.exports = grammar({
       choice('+=', '-=', '*=', '/=', '^='),
       $._expression
     )),
+
+    _pattern: $ => choice(
+      $.identifier,
+      $.assignment_pattern
+    ),
 
     assignment_pattern: $ => choice(
       $.object,
@@ -800,13 +795,8 @@ module.exports = grammar({
 
     formal_parameters: $ => seq(
       '(',
-      commaSep($._formal_parameter),
+      commaSep($._pattern),
       ')'
-    ),
-
-    _formal_parameter: $ => choice(
-      $.identifier,
-      $.assignment_pattern
     ),
 
     method_definition: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -42,6 +42,11 @@ module.exports = grammar({
     //    ^--- arrow function parameters or comma expression?
     [$.formal_parameters, $._expression],
 
+    // ( foo
+    // ( foo
+    //    ^-- arrow function parameter or parenthesized expression?
+    [$._formal_parameter, $._expression],
+
     // ( {foo} )
     // ( [foo] )
     //    ^-- destructured arrow function parameters or parenthesized expression?
@@ -795,11 +800,13 @@ module.exports = grammar({
 
     formal_parameters: $ => seq(
       '(',
-      commaSep(choice(
-        $.identifier,
-        $.assignment_pattern
-      )),
+      commaSep($._formal_parameter),
       ')'
+    ),
+
+    _formal_parameter: $ => choice(
+      $.identifier,
+      $.assignment_pattern
     ),
 
     method_definition: $ => seq(

--- a/grammar_test/destructuring.txt
+++ b/grammar_test/destructuring.txt
@@ -14,13 +14,13 @@ const {a, b: {c, d}} = object
       (identifier)
       (identifier)))
     (identifier)))
-  (var_declaration (var_assignment
+  (variable_declaration (variable_declarator
     (assignment_pattern (object
       (identifier)
       (identifier)
       (spread_element (identifier))))
     (identifier)))
-  (var_declaration (var_assignment
+  (variable_declaration (variable_declarator
     (assignment_pattern (object
       (identifier)
       (pair

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -13,7 +13,7 @@ if (a) {
 
 (program
   (if_statement (identifier) (statement_block
-    (var_declaration (var_assignment (identifier) (identifier)))
+    (variable_declaration (variable_declarator (identifier) (identifier)))
     (expression_statement (function_call (identifier) (arguments)))
     (expression_statement (function_call (identifier) (arguments)))
     (return_statement (identifier)))))
@@ -77,7 +77,7 @@ var a = new A()
 ---
 
 (program
-  (var_declaration (var_assignment
+  (variable_declaration (variable_declarator
     (identifier)
     (function_call
       (member_access
@@ -125,7 +125,7 @@ if (p) { var q }
       (statement_block (expression_statement (identifier)))
       (identifier))))
   (if_statement (identifier) (statement_block
-    (trailing_var_declaration (identifier)))))
+    (trailing_variable_declaration (variable_declarator (identifier))))))
 
 =====================================================
 Single-line declarations without semicolons

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -57,9 +57,16 @@ export { import1 as name1, import2 as name2, nameN } from 'foo';
   (export_statement
     (export_clause (export_specifier (identifier) (identifier)) (export_specifier (identifier) (identifier)) (export_specifier (identifier))))
   (export_statement
-    (var_declaration (identifier) (identifier) (identifier)))
+    (variable_declaration
+      (variable_declarator (identifier))
+      (variable_declarator (identifier))
+      (variable_declarator (identifier))))
   (export_statement
-    (var_declaration (var_assignment (identifier) (identifier)) (var_assignment (identifier) (identifier)) (identifier) (identifier)))
+    (variable_declaration
+      (variable_declarator (identifier) (identifier))
+      (variable_declarator (identifier) (identifier))
+      (variable_declarator (identifier))
+      (variable_declarator (identifier))))
   (export_statement
     (identifier))
   (export_statement
@@ -148,7 +155,9 @@ for (;;) {
 
 (program
   (for_statement
-    (var_declaration (identifier) (identifier))
+    (variable_declaration
+      (variable_declarator (identifier))
+      (variable_declarator (identifier)))
     (identifier)
     (identifier)
     (expression_statement (identifier)))
@@ -259,7 +268,7 @@ return 1,2;
   (return_statement (comma_op (number) (number))))
 
 ============================================
-Var declarations
+Variable declarations
 ============================================
 
 var x = 1;
@@ -268,12 +277,12 @@ var x, y = {}, z;
 ---
 
 (program
-  (var_declaration
-    (var_assignment (identifier) (number)))
-  (var_declaration
-    (identifier)
-    (var_assignment (identifier) (object))
-    (identifier)))
+  (variable_declaration
+    (variable_declarator (identifier) (number)))
+  (variable_declaration
+    (variable_declarator (identifier))
+    (variable_declarator (identifier) (object))
+    (variable_declarator (identifier))))
 
 ============================================
 Comments
@@ -323,7 +332,7 @@ var thing = {
 (program
   (comment)
   (comment)
-  (var_declaration (var_assignment
+  (variable_declaration (variable_declarator
     (identifier)
     (object
       (comment)
@@ -360,14 +369,14 @@ const d = 1
 
 (program
   (comment)
-  (var_declaration
-    (var_assignment (identifier) (number)))
+  (variable_declaration
+    (variable_declarator (identifier) (number)))
    (comment)
-   (var_declaration (var_assignment (identifier) (number)))
+   (variable_declaration (variable_declarator (identifier) (number)))
    (comment)
-   (var_declaration (var_assignment (identifier) (number)))
+   (variable_declaration (variable_declarator (identifier) (number)))
    (comment)
-   (var_declaration (var_assignment (identifier) (number))))
+   (variable_declaration (variable_declarator (identifier) (number))))
 
 ==========================================
 Comments within expressions

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3945,17 +3945,8 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "identifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "assignment_pattern"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_formal_parameter"
                 },
                 {
                   "type": "REPEAT",
@@ -3967,17 +3958,8 @@
                         "value": ","
                       },
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "identifier"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "assignment_pattern"
-                          }
-                        ]
+                        "type": "SYMBOL",
+                        "name": "_formal_parameter"
                       }
                     ]
                   }
@@ -3992,6 +3974,19 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "_formal_parameter": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assignment_pattern"
         }
       ]
     },
@@ -4139,6 +4134,10 @@
     ],
     [
       "formal_parameters",
+      "_expression"
+    ],
+    [
+      "_formal_parameter",
       "_expression"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -286,7 +286,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "var_declaration"
+            "name": "variable_declaration"
           }
         ]
       }
@@ -622,7 +622,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "trailing_var_declaration"
+          "name": "trailing_variable_declaration"
         }
       ]
     },
@@ -675,7 +675,7 @@
         }
       ]
     },
-    "var_declaration": {
+    "variable_declaration": {
       "type": "SEQ",
       "members": [
         {
@@ -699,21 +699,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "assignment_pattern"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "var_assignment"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "variable_declarator"
             },
             {
               "type": "REPEAT",
@@ -725,21 +712,8 @@
                     "value": ","
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "assignment_pattern"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "var_assignment"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "variable_declarator"
                   }
                 ]
               }
@@ -761,7 +735,7 @@
         }
       ]
     },
-    "trailing_var_declaration": {
+    "trailing_variable_declaration": {
       "type": "SEQ",
       "members": [
         {
@@ -785,21 +759,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "assignment_pattern"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "var_assignment"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "variable_declarator"
             },
             {
               "type": "REPEAT",
@@ -811,24 +772,41 @@
                     "value": ","
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "assignment_pattern"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "var_assignment"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "variable_declarator"
                   }
                 ]
               }
+            }
+          ]
+        }
+      ]
+    },
+    "variable_declarator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_pattern"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
             }
           ]
         }
@@ -1006,7 +984,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "var_declaration"
+              "name": "variable_declaration"
             },
             {
               "type": "SEQ",
@@ -1102,7 +1080,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "var_declaration"
+              "name": "variable_declaration"
             },
             {
               "type": "SEQ",
@@ -1865,32 +1843,6 @@
         {
           "type": "SYMBOL",
           "name": "statement_block"
-        }
-      ]
-    },
-    "var_assignment": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "assignment_pattern"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "="
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
         }
       ]
     },
@@ -2719,11 +2671,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "assignment_pattern"
+                "name": "_pattern"
               }
             ]
           },
@@ -2792,6 +2740,19 @@
           }
         ]
       }
+    },
+    "_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assignment_pattern"
+        }
+      ]
     },
     "assignment_pattern": {
       "type": "CHOICE",
@@ -3946,7 +3907,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "_formal_parameter"
+                  "name": "_pattern"
                 },
                 {
                   "type": "REPEAT",
@@ -3959,7 +3920,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "_formal_parameter"
+                        "name": "_pattern"
                       }
                     ]
                   }
@@ -3974,19 +3935,6 @@
         {
           "type": "STRING",
           "value": ")"
-        }
-      ]
-    },
-    "_formal_parameter": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "assignment_pattern"
         }
       ]
     },
@@ -4137,7 +4085,7 @@
       "_expression"
     ],
     [
-      "_formal_parameter",
+      "_pattern",
       "_expression"
     ],
     [


### PR DESCRIPTION
⚠️ WIP ⚠️ 

See https://github.com/tree-sitter/tree-sitter-typescript

I think that [the Shift](http://shift-ast.org/parser.html) and the [ESTree](https://github.com/estree/estree) AST formats are probably the best guides for how we should structure this grammar, so if we're restructuring things, we should generally consult those.

* Extract a common `_pattern` rule that can be overridden by typescript. Should this be called `_binding` 😕 ?
* Rename `var_declaration` -> `variable_declaration`.
* Get rid of `var_assignment`, make every component of a variable declaration a `var_declarator` (whether it has an initializer or not).

/cc @joshvera Feel free to take this over or replace it with something completely different ⛵️ !