### PR TITLE
Add class_heritage and lexical declaration

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -87,7 +87,8 @@ module.exports = grammar({
       $.function,
       $.generator_function,
       $.class,
-      $.lexical_declaration
+      $.lexical_declaration,
+      $.variable_declaration
     )),
 
     //
@@ -139,7 +140,6 @@ module.exports = grammar({
       $._declaration,
       $.statement_block,
 
-      $.variable_statement,
       $.if_statement,
       $.switch_statement,
       $.for_statement,
@@ -188,7 +188,7 @@ module.exports = grammar({
       choice($._expression, $.comma_op)
     ),
 
-    variable_statement: $ => seq(
+    variable_declaration: $ => seq(
       'var',
       commaSep1($.variable_declarator),
       terminator()
@@ -196,11 +196,11 @@ module.exports = grammar({
 
     lexical_declaration: $ => seq(
       letOrConst(),
-      commaSep1($.lexical_binding),
+      commaSep1($.variable_declarator),
       terminator()
     ),
 
-    lexical_binding: $ => choice(
+    variable_declarator: $ => choice(
       seq($.identifier, optional($._initializer)),
       seq($.assignment_pattern, $._initializer)
     ),
@@ -208,14 +208,6 @@ module.exports = grammar({
     trailing_variable_statement: $ => seq(
       'var',
       commaSep1($.variable_declarator)
-    ),
-
-    variable_declarator: $ => seq(
-      pattern($),
-      optional(seq(
-        '=',
-        $._expression
-      ))
     ),
 
     statement_block: $ => seq(
@@ -256,7 +248,7 @@ module.exports = grammar({
 
     _for_declaration: $ => choice(
       $.lexical_declaration,
-      $.variable_statement
+      $.variable_declaration
     ),
 
     for_statement: $ => seq(
@@ -837,10 +829,9 @@ module.exports = grammar({
       repeat(seq(
         optional('static'),
         choice(
-          $.method_definition,
-          $._public_field_definition
-        ),
-        optional(';')
+          seq($.method_definition, optional(';')),
+          seq($._public_field_definition, terminator())
+        )
       )),
       '}'
     ),

--- a/grammar_test/destructuring.txt
+++ b/grammar_test/destructuring.txt
@@ -14,13 +14,13 @@ const {a, b: {c, d}} = object
       (identifier)
       (identifier)))
     (identifier)))
-  (variable_declaration (variable_declarator
+  (lexical_declaration (variable_declarator
     (assignment_pattern (object
       (identifier)
       (identifier)
       (spread_element (identifier))))
     (identifier)))
-  (variable_declaration (variable_declarator
+  (lexical_declaration (variable_declarator
     (assignment_pattern (object
       (identifier)
       (pair

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -260,7 +260,7 @@ class Foo extends require('another-class') {
   (expression_statement
     (class
       (identifier)
-      (function_call (identifier) (arguments (string)))
+      (class_heritage (function_call (identifier) (arguments (string))))
       (class_body
         (method_definition
           (identifier)

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -125,7 +125,7 @@ if (p) { var q }
       (statement_block (expression_statement (identifier)))
       (identifier))))
   (if_statement (identifier) (statement_block
-    (trailing_variable_declaration (variable_declarator (identifier))))))
+    (trailing_variable_statement (variable_declarator (identifier))))))
 
 =====================================================
 Single-line declarations without semicolons

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -57,12 +57,12 @@ export { import1 as name1, import2 as name2, nameN } from 'foo';
   (export_statement
     (export_clause (export_specifier (identifier) (identifier)) (export_specifier (identifier) (identifier)) (export_specifier (identifier))))
   (export_statement
-    (variable_declaration
+    (lexical_declaration
       (variable_declarator (identifier))
       (variable_declarator (identifier))
       (variable_declarator (identifier))))
   (export_statement
-    (variable_declaration
+    (lexical_declaration
       (variable_declarator (identifier) (identifier))
       (variable_declarator (identifier) (identifier))
       (variable_declarator (identifier))
@@ -369,14 +369,14 @@ const d = 1
 
 (program
   (comment)
-  (variable_declaration
+  (lexical_declaration
     (variable_declarator (identifier) (number)))
    (comment)
-   (variable_declaration (variable_declarator (identifier) (number)))
+   (lexical_declaration (variable_declarator (identifier) (number)))
    (comment)
-   (variable_declaration (variable_declarator (identifier) (number)))
+   (lexical_declaration (variable_declarator (identifier) (number)))
    (comment)
-   (variable_declaration (variable_declarator (identifier) (number))))
+   (lexical_declaration (variable_declarator (identifier) (number))))
 
 ==========================================
 Comments within expressions

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -286,7 +286,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "variable_declaration"
+            "name": "lexical_declaration"
           }
         ]
       }
@@ -513,6 +513,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "variable_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "if_statement"
         },
         {
@@ -626,7 +630,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "trailing_variable_declaration"
+          "name": "trailing_variable_statement"
         }
       ]
     },
@@ -679,25 +683,12 @@
         }
       ]
     },
-    "variable_declaration": {
+    "variable_statement": {
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "var"
-            },
-            {
-              "type": "STRING",
-              "value": "let"
-            },
-            {
-              "type": "STRING",
-              "value": "const"
-            }
-          ]
+          "type": "STRING",
+          "value": "var"
         },
         {
           "type": "SEQ",
@@ -739,16 +730,12 @@
         }
       ]
     },
-    "trailing_variable_declaration": {
+    "lexical_declaration": {
       "type": "SEQ",
       "members": [
         {
           "type": "CHOICE",
           "members": [
-            {
-              "type": "STRING",
-              "value": "var"
-            },
             {
               "type": "STRING",
               "value": "let"
@@ -758,6 +745,92 @@
               "value": "const"
             }
           ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "lexical_binding"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "lexical_binding"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_line_break"
+            }
+          ]
+        }
+      ]
+    },
+    "lexical_binding": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_initializer"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "assignment_pattern"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_initializer"
+            }
+          ]
+        }
+      ]
+    },
+    "trailing_variable_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "var"
         },
         {
           "type": "SEQ",
@@ -981,6 +1054,19 @@
         }
       ]
     },
+    "for_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "lexical_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "variable_statement"
+        }
+      ]
+    },
     "for_statement": {
       "type": "SEQ",
       "members": [
@@ -997,7 +1083,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "variable_declaration"
+              "name": "for_declaration"
             },
             {
               "type": "SEQ",
@@ -1093,7 +1179,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "variable_declaration"
+              "name": "for_declaration"
             },
             {
               "type": "SEQ",
@@ -2508,17 +2594,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "extends"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "class_heritage"
             },
             {
               "type": "BLANK"
@@ -2528,6 +2605,19 @@
         {
           "type": "SYMBOL",
           "name": "class_body"
+        }
+      ]
+    },
+    "class_heritage": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "extends"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -287,6 +287,10 @@
           {
             "type": "SYMBOL",
             "name": "lexical_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "variable_declaration"
           }
         ]
       }
@@ -513,10 +517,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "variable_statement"
-        },
-        {
-          "type": "SYMBOL",
           "name": "if_statement"
         },
         {
@@ -683,7 +683,7 @@
         }
       ]
     },
-    "variable_statement": {
+    "variable_declaration": {
       "type": "SEQ",
       "members": [
         {
@@ -751,7 +751,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "lexical_binding"
+              "name": "variable_declarator"
             },
             {
               "type": "REPEAT",
@@ -764,7 +764,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "lexical_binding"
+                    "name": "variable_declarator"
                   }
                 ]
               }
@@ -786,7 +786,7 @@
         }
       ]
     },
-    "lexical_binding": {
+    "variable_declarator": {
       "type": "CHOICE",
       "members": [
         {
@@ -854,45 +854,6 @@
                   }
                 ]
               }
-            }
-          ]
-        }
-      ]
-    },
-    "variable_declarator": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "assignment_pattern"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
             }
           ]
         }
@@ -1054,7 +1015,7 @@
         }
       ]
     },
-    "for_declaration": {
+    "_for_declaration": {
       "type": "CHOICE",
       "members": [
         {
@@ -1063,7 +1024,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "variable_statement"
+          "name": "variable_declaration"
         }
       ]
     },
@@ -1083,7 +1044,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "for_declaration"
+              "name": "_for_declaration"
             },
             {
               "type": "SEQ",
@@ -1179,7 +1140,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "for_declaration"
+              "name": "_for_declaration"
             },
             {
               "type": "SEQ",
@@ -4379,24 +4340,47 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "method_definition"
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "method_definition"
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ";"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_public_field_definition"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ";"
-                  },
-                  {
-                    "type": "BLANK"
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_public_field_definition"
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ";"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_line_break"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
Splits `variable_declaration` into `lexical_declaration` and `variable_declaration`. Mostly for ambient declarations in `tree-sitter-typescript`.