### PR TITLE
Allow cover initialized names in object literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -49,7 +49,11 @@ module.exports = grammar({
 
     // { key ,
     //    ^--- shorthand object property or comma expression in block?
-    [$._expression, $._property_definition_list]
+    [$._expression, $._property_definition_list],
+
+    // { key = 5,
+    //         ^ comma expression assignment in a block or cover_initialized_name in an object?
+    [$.cover_initialized_name, $.assignment]
   ],
 
   rules: {
@@ -505,8 +509,14 @@ module.exports = grammar({
       $.method_definition,
       $.identifier,
       $.reserved_identifier,
-      $.spread_element
+      $.spread_element,
+      $.cover_initialized_name
     )),
+
+    cover_initialized_name: $ => seq(
+      $.identifier,
+      $._initializer
+    ),
 
     array: $ => seq(
       '[', optional($._element_list), ']'

--- a/grammar.js
+++ b/grammar.js
@@ -579,8 +579,7 @@ module.exports = grammar({
       optional(','),
       commaSep1Trailing($._element_list, choice(
         $._expression,
-        $.spread_element,
-        $.cover_initialized_name
+        $.spread_element
       ))),
 
     // Anonymous class declarations only occur in exports

--- a/grammar.js
+++ b/grammar.js
@@ -45,7 +45,7 @@ module.exports = grammar({
     // ( {foo} )
     // ( [foo] )
     //    ^-- destructured arrow function parameters or parenthesized expression?
-    [$.assignment_pattern, $._expression],
+    [$.destructuring_pattern, $._expression],
 
     // { key ,
     //    ^--- shorthand object property or comma expression in block?
@@ -206,7 +206,7 @@ module.exports = grammar({
 
     variable_declarator: $ => choice(
       seq($.identifier, optional($._initializer)),
-      seq($.assignment_pattern, $._initializer)
+      seq($.destructuring_pattern, $._initializer)
     ),
 
     trailing_variable_statement: $ => seq(
@@ -680,7 +680,7 @@ module.exports = grammar({
       $._expression
     )),
 
-    assignment_pattern: $ => choice(
+    destructuring_pattern: $ => choice(
       $.object,
       $.array
     ),
@@ -904,5 +904,5 @@ function letOrConst () {
 }
 
 function pattern ($) {
-  return choice($.identifier, $.assignment_pattern)
+  return choice($.identifier, $.destructuring_pattern)
 }

--- a/grammar.js
+++ b/grammar.js
@@ -52,8 +52,8 @@ module.exports = grammar({
     [$._expression, $._property_definition_list],
 
     // { key = 5,
-    //         ^ comma expression assignment in a block or cover_initialized_name in an object?
-    [$.cover_initialized_name, $.assignment]
+    //         ^ comma expression assignment in a block or assignment_pattern in an object?
+    [$.assignment_pattern, $.assignment]
   ],
 
   rules: {
@@ -510,10 +510,10 @@ module.exports = grammar({
       $.identifier,
       $.reserved_identifier,
       $.spread_element,
-      $.cover_initialized_name
+      $.assignment_pattern
     )),
 
-    cover_initialized_name: $ => seq(
+    assignment_pattern: $ => seq(
       $.identifier,
       $._initializer
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -579,7 +579,8 @@ module.exports = grammar({
       optional(','),
       commaSep1Trailing($._element_list, choice(
         $._expression,
-        $.spread_element
+        $.spread_element,
+        $.cover_initialized_name
       ))),
 
     // Anonymous class declarations only occur in exports

--- a/grammar_test/destructuring.txt
+++ b/grammar_test/destructuring.txt
@@ -10,18 +10,18 @@ const {a, b: {c, d}} = object
 
 (program
   (expression_statement (assignment
-    (assignment_pattern (object
+    (destructuring_pattern (object
       (identifier)
       (identifier)))
     (identifier)))
   (lexical_declaration (variable_declarator
-    (assignment_pattern (object
+    (destructuring_pattern (object
       (identifier)
       (identifier)
       (spread_element (identifier))))
     (identifier)))
   (lexical_declaration (variable_declarator
-    (assignment_pattern (object
+    (destructuring_pattern (object
       (identifier)
       (pair
         (identifier)
@@ -42,8 +42,8 @@ function a ({b, c}, {d}) {}
   (expression_statement
     (function (identifier)
       (formal_parameters
-        (assignment_pattern (object (identifier) (identifier)))
-        (assignment_pattern (object (identifier))))
+        (destructuring_pattern (object (identifier) (identifier)))
+        (destructuring_pattern (object (identifier))))
       (statement_block))))
 
 ============================================
@@ -57,12 +57,12 @@ Array destructuring assignments
 
 (program
   (expression_statement (assignment
-    (assignment_pattern (array
+    (destructuring_pattern (array
       (identifier)
       (identifier)))
     (identifier)))
   (expression_statement (assignment
-    (assignment_pattern (array
+    (destructuring_pattern (array
       (identifier)
       (identifier)
       (spread_element (identifier))))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -297,6 +297,7 @@ Arrays
 [ "item1", ];
 [ "item1", item2 ];
 [ , item2 ];
+[ item2 = 5 ];
 
 ---
 
@@ -305,7 +306,8 @@ Arrays
   (expression_statement (array (string)))
   (expression_statement (array (string)))
   (expression_statement (array (string) (identifier)))
-  (expression_statement (array (identifier))))
+  (expression_statement (array (identifier)))
+  (expression_statement (array (assignment (identifier) (number)))))
 
 ============================================
 Functions

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -114,6 +114,7 @@ Objects
 {};
 { key1: "value1" };
 { key1: "value1", "key2": value2, key3: 3.0 };
+{ x = 5 };
 
 ---
 
@@ -124,7 +125,9 @@ Objects
   (expression_statement (object
     (pair (identifier) (string))
     (pair (string) (identifier))
-    (pair (identifier) (number)))))
+    (pair (identifier) (number))))
+  (expression_statement (object
+    (cover_initialized_name (identifier) (number)))))
 
 ============================================
 Objects with shorthand properties

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -297,6 +297,7 @@ Arrays
 [ "item1", ];
 [ "item1", item2 ];
 [ , item2 ];
+[ x = 5 ];
 
 ---
 
@@ -305,7 +306,8 @@ Arrays
   (expression_statement (array (string)))
   (expression_statement (array (string)))
   (expression_statement (array (string) (identifier)))
-  (expression_statement (array (identifier))))
+  (expression_statement (array (identifier)))
+  (expression_statement (array (assignment (identifier) (number)))))
 
 ============================================
 Functions

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -297,7 +297,6 @@ Arrays
 [ "item1", ];
 [ "item1", item2 ];
 [ , item2 ];
-[ x = 5 ];
 
 ---
 
@@ -306,8 +305,7 @@ Arrays
   (expression_statement (array (string)))
   (expression_statement (array (string)))
   (expression_statement (array (string) (identifier)))
-  (expression_statement (array (identifier)))
-  (expression_statement (array (assignment (identifier) (number)))))
+  (expression_statement (array (identifier))))
 
 ============================================
 Functions

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -127,7 +127,7 @@ Objects
     (pair (string) (identifier))
     (pair (identifier) (number))))
   (expression_statement (object
-    (cover_initialized_name (identifier) (number)))))
+    (assignment_pattern (identifier) (number)))))
 
 ============================================
 Objects with shorthand properties

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -815,7 +815,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "assignment_pattern"
+              "name": "destructuring_pattern"
             },
             {
               "type": "SYMBOL",
@@ -2259,15 +2259,15 @@
       ]
     },
     "assignment_pattern": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "object"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
-          "name": "array"
+          "name": "_initializer"
         }
       ]
     },
@@ -2869,7 +2869,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "assignment_pattern"
+                    "name": "destructuring_pattern"
                   }
                 ]
               }
@@ -2961,6 +2961,19 @@
           }
         ]
       }
+    },
+    "destructuring_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "object"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array"
+        }
+      ]
     },
     "spread_element": {
       "type": "SEQ",
@@ -4471,7 +4484,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "assignment_pattern"
+                      "name": "destructuring_pattern"
                     }
                   ]
                 },
@@ -4493,7 +4506,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "assignment_pattern"
+                            "name": "destructuring_pattern"
                           }
                         ]
                       }
@@ -4660,7 +4673,7 @@
       "_expression"
     ],
     [
-      "assignment_pattern",
+      "destructuring_pattern",
       "_expression"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2511,6 +2511,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "spread_element"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "cover_initialized_name"
                 }
               ]
             },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2220,6 +2220,10 @@
             {
               "type": "SYMBOL",
               "name": "spread_element"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "cover_initialized_name"
             }
           ]
         },
@@ -2251,6 +2255,19 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "cover_initialized_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_initializer"
         }
       ]
     },
@@ -4662,6 +4679,10 @@
     [
       "_expression",
       "_property_definition_list"
+    ],
+    [
+      "cover_initialized_name",
+      "assignment"
     ]
   ],
   "externals": []

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2511,10 +2511,6 @@
                 {
                   "type": "SYMBOL",
                   "name": "spread_element"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "cover_initialized_name"
                 }
               ]
             },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2223,7 +2223,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "cover_initialized_name"
+              "name": "assignment_pattern"
             }
           ]
         },
@@ -2258,16 +2258,16 @@
         }
       ]
     },
-    "cover_initialized_name": {
-      "type": "SEQ",
+    "assignment_pattern": {
+      "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "object"
         },
         {
           "type": "SYMBOL",
-          "name": "_initializer"
+          "name": "array"
         }
       ]
     },
@@ -2961,19 +2961,6 @@
           }
         ]
       }
-    },
-    "assignment_pattern": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "object"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "array"
-        }
-      ]
     },
     "spread_element": {
       "type": "SEQ",
@@ -4681,7 +4668,7 @@
       "_property_definition_list"
     ],
     [
-      "cover_initialized_name",
+      "assignment_pattern",
       "assignment"
     ]
   ],


### PR DESCRIPTION
Since `{ x = 5 }` is a valid.