### PR TITLE
Model automatic semicolon insertion using an external scanner

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,7 @@
       ],
       "sources": [
         "src/parser.c",
+        "src/scanner.c",
         "src/binding.cc"
       ],
       "cflags_c": [

--- a/grammar.js
+++ b/grammar.js
@@ -24,12 +24,13 @@ module.exports = grammar({
   name: 'javascript',
 
   externals: $ => [
-    $._automatic_semicolon
+    $._automatic_semicolon,
+    '}'
   ],
 
   extras: $ => [
     $.comment,
-    /[ \t\n\r\uFEFF\u2060\u200B]/
+    /[\s\uFEFF\u2060\u200B]/
   ],
 
   conflicts: $ => [

--- a/grammar_test/destructuring.txt
+++ b/grammar_test/destructuring.txt
@@ -39,18 +39,17 @@ function a ({b, c}, {d}) {}
 ---
 
 (program
-  (expression_statement
-    (function (identifier)
-      (formal_parameters
-        (assignment_pattern (object (identifier) (identifier)))
-        (assignment_pattern (object (identifier))))
-      (statement_block))))
+  (function (identifier)
+    (formal_parameters
+      (assignment_pattern (object (identifier) (identifier)))
+      (assignment_pattern (object (identifier))))
+    (statement_block)))
 
 ============================================
 Array destructuring assignments
 ============================================
 
-[a, b] = array
+[a, b] = array;
 [a, b, ...c] = array
 
 ---

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -240,33 +240,31 @@ class Foo extends require('another-class') {
 ---
 
 (program
-  (expression_statement
-    (class
-      (identifier)
-      (class_body
-        (method_definition
-          (identifier)
-          (formal_parameters (identifier))
-          (statement_block (return_statement (identifier))))
-        (method_definition
-          (identifier)
-          (formal_parameters (identifier))
-          (statement_block (return_statement (identifier))))
-        (method_definition
-          (identifier)
-          (formal_parameters (identifier))
-          (statement_block (return_statement (identifier)))))))
+  (class
+    (identifier)
+    (class_body
+      (method_definition
+        (identifier)
+        (formal_parameters (identifier))
+        (statement_block (return_statement (identifier))))
+      (method_definition
+        (identifier)
+        (formal_parameters (identifier))
+        (statement_block (return_statement (identifier))))
+      (method_definition
+        (identifier)
+        (formal_parameters (identifier))
+        (statement_block (return_statement (identifier))))))
 
-  (expression_statement
-    (class
-      (identifier)
-      (class_heritage (function_call (identifier) (arguments (string))))
-      (class_body
-        (method_definition
-          (identifier)
-          (formal_parameters)
-          (statement_block
-            (expression_statement (function_call (super) (arguments)))))))))
+  (class
+    (identifier)
+    (class_heritage (function_call (identifier) (arguments (string))))
+    (class_body
+      (method_definition
+        (identifier)
+        (formal_parameters)
+        (statement_block
+          (expression_statement (function_call (super) (arguments))))))))
 
 ============================================
 Class Property Fields
@@ -279,11 +277,10 @@ class Foo {
 ---
 
 (program
-  (expression_statement
-    (class
-      (identifier)
-      (class_body
-        (variable_declarator (identifier) (number))))))
+  (class
+    (identifier)
+    (class_body
+      (variable_declarator (identifier) (number)))))
 
 ============================================
 Arrays
@@ -524,23 +521,21 @@ async (a) => { return foo; };
 ---
 
 (program
-  (expression_statement
-    (function
-      (identifier)
-      (formal_parameters)
-      (statement_block)))
+  (function
+    (identifier)
+    (formal_parameters)
+    (statement_block))
   (expression_statement
     (object
       (method_definition
         (identifier)
         (formal_parameters)
         (statement_block))))
-  (expression_statement
-    (class (identifier) (class_body
-      (method_definition
-        (identifier)
-        (formal_parameters)
-        (statement_block)))))
+  (class (identifier) (class_body
+    (method_definition
+      (identifier)
+      (formal_parameters)
+      (statement_block))))
   (expression_statement
     (arrow_function
       (formal_parameters (identifier))

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -49,6 +49,47 @@ indented code after blocks
     (statement_block))
   (return_statement (identifier)))
 
+================================================
+Alphabetical infix operators split across lines
+================================================
+
+a
+  i;
+
+a
+  in b;
+
+a
+  ins;
+
+a
+  inst;
+
+a
+  instanceof b;
+
+a
+  instanceofX;
+
+---
+
+(program
+  (expression_statement (identifier))
+  (expression_statement (identifier))
+
+  (expression_statement (type_op (identifier) (identifier)))
+
+  (expression_statement (identifier))
+  (expression_statement (identifier))
+
+  (expression_statement (identifier))
+  (expression_statement (identifier))
+
+  (expression_statement (type_op (identifier) (identifier)))
+
+  (expression_statement (identifier))
+  (expression_statement (identifier)))
+
 ===========================================
 single-line blocks without semicolons
 ===========================================

--- a/grammar_test/semicolon_insertion.txt
+++ b/grammar_test/semicolon_insertion.txt
@@ -43,10 +43,10 @@ indented code after blocks
 ---
 
 (program
-  (expression_statement (function
+  (function
     (identifier)
     (formal_parameters)
-    (statement_block)))
+    (statement_block))
   (return_statement (identifier)))
 
 ===========================================
@@ -59,12 +59,10 @@ function c() {return d}
 ---
 
 (program
-  (expression_statement
-    (function (identifier) (formal_parameters) (statement_block
-      (trailing_expression_statement (identifier)))))
-  (expression_statement
-    (function (identifier) (formal_parameters) (statement_block
-      (trailing_return_statement (identifier))))))
+  (function (identifier) (formal_parameters) (statement_block
+    (expression_statement (identifier))))
+  (function (identifier) (formal_parameters) (statement_block
+    (return_statement (identifier)))))
 
 ==============================================
 Multi-line chained expressions in var declarations
@@ -79,15 +77,15 @@ var a = new A()
 (program
   (variable_declaration (variable_declarator
     (identifier)
-    (function_call
+    (new_expression (function_call
       (member_access
         (function_call
           (member_access
-            (new_expression (function_call (identifier) (arguments)))
+            (function_call (identifier) (arguments))
             (identifier))
           (arguments (object (pair (identifier) (string)))))
         (identifier))
-      (arguments)))))
+      (arguments))))))
 
 ==============================================
 if/for/while/do statements without semicolons
@@ -105,27 +103,27 @@ if (p) { var q }
 
 (program
   (if_statement (identifier) (statement_block
-    (trailing_if_statement
+    (if_statement
       (identifier)
-      (trailing_return_statement (identifier)))))
+      (return_statement (identifier)))))
   (if_statement (identifier) (statement_block
-    (trailing_for_statement
-      (trailing_break_statement))))
+    (for_statement
+      (break_statement))))
   (if_statement (identifier) (statement_block
-    (trailing_for_in_statement (identifier) (identifier)
-      (trailing_break_statement))))
+    (for_in_statement (identifier) (identifier)
+      (break_statement))))
   (if_statement (identifier) (statement_block
-    (trailing_for_of_statement (identifier) (identifier)
-      (trailing_continue_statement))))
+    (for_of_statement (identifier) (identifier)
+      (continue_statement))))
   (if_statement (identifier) (statement_block
-    (trailing_while_statement (identifier)
-      (trailing_break_statement))))
+    (while_statement (identifier)
+      (break_statement))))
   (if_statement (identifier) (statement_block
-    (trailing_do_statement
+    (do_statement
       (statement_block (expression_statement (identifier)))
       (identifier))))
   (if_statement (identifier) (statement_block
-    (trailing_variable_statement (variable_declarator (identifier))))))
+    (variable_declaration (variable_declarator (identifier))))))
 
 =====================================================
 Single-line declarations without semicolons
@@ -139,4 +137,4 @@ function a () { function b () {} function *c () {} class D {} return }
     (function (identifier) (formal_parameters) (statement_block))
     (generator_function (identifier) (formal_parameters) (statement_block))
     (class (identifier) (class_body))
-    (trailing_return_statement))))
+    (return_statement))))

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -368,14 +368,13 @@ const d = 1
 
 (program
   (comment)
-  (lexical_declaration
-    (variable_declarator (identifier) (number)))
-   (comment)
-   (lexical_declaration (variable_declarator (identifier) (number)))
-   (comment)
-   (lexical_declaration (variable_declarator (identifier) (number)))
-   (comment)
-   (lexical_declaration (variable_declarator (identifier) (number))))
+  (lexical_declaration (variable_declarator (identifier) (number)))
+  (comment)
+  (lexical_declaration (variable_declarator (identifier) (number)))
+  (comment)
+  (lexical_declaration (variable_declarator (identifier) (number)))
+  (comment)
+  (lexical_declaration (variable_declarator (identifier) (number))))
 
 ==========================================
 Comments within expressions
@@ -442,7 +441,7 @@ throw g = 2, g
 (program
   (throw_statement
     (comma_op (assignment (identifier) (number)) (identifier)))
-  (trailing_throw_statement
+  (throw_statement
     (comma_op (assignment (identifier) (number)) (identifier))))
 
 ============================================

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -351,18 +351,18 @@ Comments with asterisks
 ============================================
 
 /* a */
-const a = 1
+const a = 1;
 
 /* b **/
-const b = 1
+const b = 1;
 
 /* c ***/
-const c = 1
+const c = 1;
 
 /* d
 
 ***/
-const d = 1
+const d = 1;
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("./build/Release/tree_sitter_javascript_binding");
+module.exports = require("./build/Debug/tree_sitter_javascript_binding");

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("./build/Debug/tree_sitter_javascript_binding");
+module.exports = require("./build/Release/tree_sitter_javascript_binding");

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "acorn": "^2.6.4",
     "babylon": "^6.3.26",
     "esprima": "^2.7.1",
-    "tree-sitter-cli": "^0.4.8"
+    "tree-sitter-cli": "^0.5.0"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2,19 +2,7 @@
   "name": "javascript",
   "rules": {
     "program": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_statements"
-        },
-        {
-          "type": "BLANK"
-        }
-      ]
-    },
-    "_statements": {
-      "type": "REPEAT1",
+      "type": "REPEAT",
       "content": {
         "type": "SYMBOL",
         "name": "_statement"
@@ -757,16 +745,11 @@
           "value": "{"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_statement"
+          }
         },
         {
           "type": "STRING",
@@ -1392,16 +1375,11 @@
           "value": ":"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_statement"
+          }
         }
       ]
     },
@@ -1417,16 +1395,11 @@
           "value": ":"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_statement"
+          }
         }
       ]
     },
@@ -4113,7 +4086,7 @@
     },
     {
       "type": "PATTERN",
-      "value": "[ \\t\\n\\r﻿⁠​]"
+      "value": "[\\s﻿⁠​]"
     }
   ],
   "conflicts": [
@@ -4139,6 +4112,13 @@
     ]
   ],
   "externals": [
-    "_automatic_semicolon"
+    {
+      "type": "SYMBOL",
+      "name": "_automatic_semicolon"
+    },
+    {
+      "type": "STRING",
+      "value": "}"
+    }
   ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -14,34 +14,11 @@
       ]
     },
     "_statements": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statement"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_trailing_statement"
-        }
-      ]
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_statement"
+      }
     },
     "export_statement": {
       "type": "CHOICE",
@@ -65,12 +42,12 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": ";"
+                  "type": "SYMBOL",
+                  "name": "_automatic_semicolon"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
+                  "type": "STRING",
+                  "value": ";"
                 }
               ]
             }
@@ -95,12 +72,12 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": ";"
+                  "type": "SYMBOL",
+                  "name": "_automatic_semicolon"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
+                  "type": "STRING",
+                  "value": ";"
                 }
               ]
             }
@@ -121,12 +98,12 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": ";"
+                  "type": "SYMBOL",
+                  "name": "_automatic_semicolon"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
+                  "type": "STRING",
+                  "value": ";"
                 }
               ]
             }
@@ -181,12 +158,12 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": ";"
+                  "type": "SYMBOL",
+                  "name": "_automatic_semicolon"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
+                  "type": "STRING",
+                  "value": ";"
                 }
               ]
             }
@@ -273,16 +250,38 @@
         "type": "CHOICE",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "function"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "generator_function"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "class"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "function"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "generator_function"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "class"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_automatic_semicolon"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
           },
           {
             "type": "SYMBOL",
@@ -328,12 +327,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": ";"
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
             },
             {
-              "type": "SYMBOL",
-              "name": "_line_break"
+              "type": "STRING",
+              "value": ";"
             }
           ]
         }
@@ -577,63 +576,6 @@
         }
       ]
     },
-    "_trailing_statement": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "trailing_break_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_continue_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_yield_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_throw_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_return_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_expression_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_if_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_for_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_for_in_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_for_of_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_while_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_do_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "trailing_variable_statement"
-        }
-      ]
-    },
     "expression_statement": {
       "type": "SEQ",
       "members": [
@@ -654,30 +596,12 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
+            },
+            {
               "type": "STRING",
               "value": ";"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_line_break"
-            }
-          ]
-        }
-      ]
-    },
-    "trailing_expression_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "comma_op"
             }
           ]
         }
@@ -719,12 +643,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": ";"
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
             },
             {
-              "type": "SYMBOL",
-              "name": "_line_break"
+              "type": "STRING",
+              "value": ";"
             }
           ]
         }
@@ -775,12 +699,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": ";"
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
             },
             {
-              "type": "SYMBOL",
-              "name": "_line_break"
+              "type": "STRING",
+              "value": ";"
             }
           ]
         }
@@ -820,40 +744,6 @@
             {
               "type": "SYMBOL",
               "name": "_initializer"
-            }
-          ]
-        }
-      ]
-    },
-    "trailing_variable_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "var"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "variable_declarator"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "variable_declarator"
-                  }
-                ]
-              }
             }
           ]
         }
@@ -919,49 +809,6 @@
                   {
                     "type": "SYMBOL",
                     "name": "_statement"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "trailing_if_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "if"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_paren_expression"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_trailing_statement"
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_statement"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "else"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_trailing_statement"
                   }
                 ]
               }
@@ -1124,102 +971,6 @@
         }
       ]
     },
-    "trailing_for_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "for"
-        },
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_for_declaration"
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ","
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_expression"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ";"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_trailing_statement"
-        }
-      ]
-    },
     "for_in_statement": {
       "type": "SEQ",
       "members": [
@@ -1275,64 +1026,6 @@
         {
           "type": "SYMBOL",
           "name": "_statement"
-        }
-      ]
-    },
-    "trailing_for_in_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "for"
-        },
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "var"
-                },
-                {
-                  "type": "STRING",
-                  "value": "let"
-                },
-                {
-                  "type": "STRING",
-                  "value": "const"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "STRING",
-          "value": "in"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_trailing_statement"
         }
       ]
     },
@@ -1394,64 +1087,6 @@
         }
       ]
     },
-    "trailing_for_of_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "for"
-        },
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "var"
-                },
-                {
-                  "type": "STRING",
-                  "value": "let"
-                },
-                {
-                  "type": "STRING",
-                  "value": "const"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "STRING",
-          "value": "of"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_trailing_statement"
-        }
-      ]
-    },
     "while_statement": {
       "type": "SEQ",
       "members": [
@@ -1466,23 +1101,6 @@
         {
           "type": "SYMBOL",
           "name": "_statement"
-        }
-      ]
-    },
-    "trailing_while_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "while"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_paren_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_trailing_statement"
         }
       ]
     },
@@ -1509,35 +1127,14 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": ";"
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
             },
             {
-              "type": "SYMBOL",
-              "name": "_line_break"
+              "type": "STRING",
+              "value": ";"
             }
           ]
-        }
-      ]
-    },
-    "trailing_do_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "do"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "statement_block"
-        },
-        {
-          "type": "STRING",
-          "value": "while"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_paren_expression"
         }
       ]
     },
@@ -1601,33 +1198,12 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
+            },
+            {
               "type": "STRING",
               "value": ";"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_line_break"
-            }
-          ]
-        }
-      ]
-    },
-    "trailing_break_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "break"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "BLANK"
             }
           ]
         }
@@ -1656,33 +1232,12 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
+            },
+            {
               "type": "STRING",
               "value": ";"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_line_break"
-            }
-          ]
-        }
-      ]
-    },
-    "trailing_continue_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "continue"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "BLANK"
             }
           ]
         }
@@ -1720,42 +1275,12 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
+            },
+            {
               "type": "STRING",
               "value": ";"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_line_break"
-            }
-          ]
-        }
-      ]
-    },
-    "trailing_return_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "return"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "comma_op"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
             }
           ]
         }
@@ -1784,33 +1309,12 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
+            },
+            {
               "type": "STRING",
               "value": ";"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_line_break"
-            }
-          ]
-        }
-      ]
-    },
-    "trailing_yield_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "yield"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "BLANK"
             }
           ]
         }
@@ -1840,34 +1344,12 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_automatic_semicolon"
+            },
+            {
               "type": "STRING",
               "value": ";"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_line_break"
-            }
-          ]
-        }
-      ]
-    },
-    "trailing_throw_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "throw"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "comma_op"
             }
           ]
         }
@@ -4419,12 +3901,12 @@
                         "type": "CHOICE",
                         "members": [
                           {
-                            "type": "STRING",
-                            "value": ";"
+                            "type": "SYMBOL",
+                            "name": "_automatic_semicolon"
                           },
                           {
-                            "type": "SYMBOL",
-                            "name": "_line_break"
+                            "type": "STRING",
+                            "value": ";"
                           }
                         ]
                       }
@@ -4622,10 +4104,6 @@
           "value": "async"
         }
       ]
-    },
-    "_line_break": {
-      "type": "STRING",
-      "value": "\n"
     }
   },
   "extras": [
@@ -4634,12 +4112,8 @@
       "name": "comment"
     },
     {
-      "type": "SYMBOL",
-      "name": "_line_break"
-    },
-    {
       "type": "PATTERN",
-      "value": "[ \\t\\r﻿⁠​]"
+      "value": "[ \\t\\n\\r﻿⁠​]"
     }
   ],
   "conflicts": [
@@ -4664,5 +4138,7 @@
       "_property_definition_list"
     ]
   ],
-  "externals": []
+  "externals": [
+    "_automatic_semicolon"
+  ]
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -4,6 +4,7 @@
 
 enum TokenType {
   AUTOMATIC_SEMICOLON,
+  RIGHT_CURLY_BRACE,
 };
 
 void *tree_sitter_javascript_external_scanner_create() {
@@ -26,7 +27,7 @@ bool tree_sitter_javascript_external_scanner_scan(void *payload, TSLexer *lexer,
 
   for (;;) {
     if (lexer->lookahead == 0) return true;
-    if (lexer->lookahead == '}') return true;
+    if (lexer->lookahead == '}') return !valid_symbols[RIGHT_CURLY_BRACE];
     if (!iswspace(lexer->lookahead)) return false;
     if (lexer->lookahead == '\n') break;
     lexer->advance(lexer, true);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,66 @@
+#include "tree_sitter/parser.h"
+#include <wctype.h>
+#include <stdio.h>
+
+enum TokenType {
+  AUTOMATIC_SEMICOLON,
+};
+
+void *tree_sitter_javascript_external_scanner_create() {
+  return NULL;
+}
+
+void tree_sitter_javascript_external_scanner_destroy(void *payload) {}
+
+void tree_sitter_javascript_external_scanner_reset(void *payload) {}
+
+bool tree_sitter_javascript_external_scanner_serialize(void *payload, TSExternalTokenState state) {
+  return true;
+}
+
+void tree_sitter_javascript_external_scanner_deserialize(void *payload, TSExternalTokenState state) {}
+
+bool tree_sitter_javascript_external_scanner_scan(void *payload, TSLexer *lexer,
+                                                  const bool *valid_symbols) {
+  lexer->result_symbol = AUTOMATIC_SEMICOLON;
+
+  for (;;) {
+    if (lexer->lookahead == 0) return true;
+    if (lexer->lookahead == '}') return true;
+    if (!iswspace(lexer->lookahead)) return false;
+    if (lexer->lookahead == '\n') break;
+    lexer->advance(lexer, true);
+  }
+
+  lexer->mark_end(lexer);
+  lexer->advance(lexer, false);
+
+  while (iswspace(lexer->lookahead)) {
+    lexer->advance(lexer, false);
+  }
+
+  switch (lexer->lookahead) {
+    case '.':
+    case '+':
+    case '-':
+    case '*':
+    case '%':
+    case '>':
+    case '<':
+    case '=':
+    case '[':
+    case '(':
+      return false;
+
+    case '/':
+      lexer->advance(lexer, false);
+      return lexer->lookahead != '*' && lexer->lookahead != '/';
+
+    case '!':
+      lexer->advance(lexer, false);
+      return lexer->lookahead != '=';
+
+    default:
+      return true;
+  }
+}

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -26,6 +26,7 @@ typedef struct {
 
 typedef struct {
   void (*advance)(void *, bool);
+  void (*mark_end)(void *);
   int32_t lookahead;
   TSSymbol result_symbol;
 } TSLexer;
@@ -91,32 +92,32 @@ typedef struct TSLanguage {
  *  Lexer Macros
  */
 
-#define START_LEXER() \
-  int32_t lookahead;  \
-  next_state:         \
+#define START_LEXER()           \
+  bool result = false;          \
+  int32_t lookahead;            \
+  next_state:                   \
   lookahead = lexer->lookahead;
 
-#define ADVANCE(state_value)                   \
-  {                                            \
+#define ADVANCE(state_value)      \
+  {                               \
     lexer->advance(lexer, false); \
-    state = state_value;                       \
-    goto next_state;                           \
+    state = state_value;          \
+    goto next_state;              \
   }
 
-#define SKIP(state_value)                     \
-  {                                           \
+#define SKIP(state_value)        \
+  {                              \
     lexer->advance(lexer, true); \
-    state = state_value;                      \
-    goto next_state;                          \
+    state = state_value;         \
+    goto next_state;             \
   }
 
-#define ACCEPT_TOKEN(symbol_value)       \
-  {                                      \
-    lexer->result_symbol = symbol_value; \
-    return true;                         \
-  }
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
 
-#define LEX_ERROR() return false
+#define END_STATE() return result;
 
 /*
  *  Parse Table Macros


### PR DESCRIPTION
This avoids the parse-stack branching that was previously happening when semicolons were omitted. It also remove `trailing_return_statement` and all of the other `trailing` rules. The parse state count has decreased from 3014 to 2441 and the parser generate time is down to about 12 seconds on my machine.

/cc @joshvera We'll have to figure out the best way to share the external scanner code between JavaScript and Typescript.