### PR TITLE
Use new grammar apis

### DIFF
--- a/corpus/destructuring.txt
+++ b/corpus/destructuring.txt
@@ -11,24 +11,24 @@ const {a, b: {c, d}} = object
 (program
   (expression_statement (assignment
     (object_pattern
-      (shorthand_property_name)
-      (shorthand_property_name))
-    (variable_name)))
+      (shorthand_property_identifier)
+      (shorthand_property_identifier))
+    (identifier)))
   (lexical_declaration (variable_declarator
     (object_pattern
-      (shorthand_property_name)
-      (shorthand_property_name)
-      (spread_element (variable_name)))
-    (variable_name)))
+      (shorthand_property_identifier)
+      (shorthand_property_identifier)
+      (spread_element (identifier)))
+    (identifier)))
   (lexical_declaration (variable_declarator
     (object_pattern
-      (shorthand_property_name)
+      (shorthand_property_identifier)
       (pair
-        (property_name)
+        (property_identifier)
         (object
-          (shorthand_property_name)
-          (shorthand_property_name))))
-    (variable_name))))
+          (shorthand_property_identifier)
+          (shorthand_property_identifier))))
+    (identifier))))
 
 ============================================
 Object destructuring parameters
@@ -39,10 +39,10 @@ function a ({b, c}, {d}) {}
 ---
 
 (program
-  (function (variable_name)
+  (function (identifier)
     (formal_parameters
-      (object_pattern (shorthand_property_name) (shorthand_property_name))
-      (object_pattern (shorthand_property_name)))
+      (object_pattern (shorthand_property_identifier) (shorthand_property_identifier))
+      (object_pattern (shorthand_property_identifier)))
     (statement_block)))
 
 ============================================
@@ -57,15 +57,15 @@ Array destructuring assignments
 (program
   (expression_statement (assignment
     (array_pattern
-      (variable_name)
-      (variable_name))
-    (variable_name)))
+      (identifier)
+      (identifier))
+    (identifier)))
   (expression_statement (assignment
     (array_pattern
-      (variable_name)
-      (variable_name)
-      (spread_element (variable_name)))
-    (variable_name))))
+      (identifier)
+      (identifier)
+      (spread_element (identifier)))
+    (identifier))))
 
 ================================================
 Object destructuring patterns w/ default values
@@ -76,8 +76,8 @@ function a({b = true}, [c, d = false]) {}
 ---
 
 (program
-  (function (variable_name)
+  (function (identifier)
     (formal_parameters
-      (object_pattern (assignment_pattern (shorthand_property_name) (true)))
-      (array_pattern (variable_name) (assignment (variable_name) (false))))
+      (object_pattern (assignment_pattern (shorthand_property_identifier) (true)))
+      (array_pattern (identifier) (assignment (identifier) (false))))
     (statement_block)))

--- a/corpus/destructuring.txt
+++ b/corpus/destructuring.txt
@@ -10,24 +10,24 @@ const {a, b: {c, d}} = object
 
 (program
   (expression_statement (assignment
-    (destructuring_pattern (object
+    (object_pattern
       (identifier)
-      (identifier)))
+      (identifier))
     (identifier)))
   (lexical_declaration (variable_declarator
-    (destructuring_pattern (object
+    (object_pattern
       (identifier)
       (identifier)
-      (spread_element (identifier))))
+      (spread_element (identifier)))
     (identifier)))
   (lexical_declaration (variable_declarator
-    (destructuring_pattern (object
+    (object_pattern
       (identifier)
       (pair
         (identifier)
         (object
           (identifier)
-          (identifier)))))
+          (identifier))))
     (identifier))))
 
 ============================================
@@ -41,8 +41,8 @@ function a ({b, c}, {d}) {}
 (program
   (function (identifier)
     (formal_parameters
-      (destructuring_pattern (object (identifier) (identifier)))
-      (destructuring_pattern (object (identifier))))
+      (object_pattern (identifier) (identifier))
+      (object_pattern (identifier)))
     (statement_block)))
 
 ============================================
@@ -56,15 +56,15 @@ Array destructuring assignments
 
 (program
   (expression_statement (assignment
-    (destructuring_pattern (array
+    (array_pattern
       (identifier)
-      (identifier)))
+      (identifier))
     (identifier)))
   (expression_statement (assignment
-    (destructuring_pattern (array
+    (array_pattern
       (identifier)
       (identifier)
-      (spread_element (identifier))))
+      (spread_element (identifier)))
     (identifier))))
 
 ================================================
@@ -78,6 +78,6 @@ function a({b = true}, [c, d = false]) {}
 (program
   (function (identifier)
     (formal_parameters
-      (destructuring_pattern (object (assignment_pattern (identifier) (true))))
-      (destructuring_pattern (array (identifier) (assignment (identifier) (false)))))
+      (object_pattern (assignment_pattern (identifier) (true)))
+      (array_pattern (identifier) (assignment (identifier) (false))))
     (statement_block)))

--- a/corpus/destructuring.txt
+++ b/corpus/destructuring.txt
@@ -11,24 +11,24 @@ const {a, b: {c, d}} = object
 (program
   (expression_statement (assignment
     (object_pattern
-      (identifier)
-      (identifier))
-    (identifier)))
+      (shorthand_property_name)
+      (shorthand_property_name))
+    (variable_name)))
   (lexical_declaration (variable_declarator
     (object_pattern
-      (identifier)
-      (identifier)
-      (spread_element (identifier)))
-    (identifier)))
+      (shorthand_property_name)
+      (shorthand_property_name)
+      (spread_element (variable_name)))
+    (variable_name)))
   (lexical_declaration (variable_declarator
     (object_pattern
-      (identifier)
+      (shorthand_property_name)
       (pair
-        (identifier)
+        (property_name)
         (object
-          (identifier)
-          (identifier))))
-    (identifier))))
+          (shorthand_property_name)
+          (shorthand_property_name))))
+    (variable_name))))
 
 ============================================
 Object destructuring parameters
@@ -39,10 +39,10 @@ function a ({b, c}, {d}) {}
 ---
 
 (program
-  (function (identifier)
+  (function (variable_name)
     (formal_parameters
-      (object_pattern (identifier) (identifier))
-      (object_pattern (identifier)))
+      (object_pattern (shorthand_property_name) (shorthand_property_name))
+      (object_pattern (shorthand_property_name)))
     (statement_block)))
 
 ============================================
@@ -57,15 +57,15 @@ Array destructuring assignments
 (program
   (expression_statement (assignment
     (array_pattern
-      (identifier)
-      (identifier))
-    (identifier)))
+      (variable_name)
+      (variable_name))
+    (variable_name)))
   (expression_statement (assignment
     (array_pattern
-      (identifier)
-      (identifier)
-      (spread_element (identifier)))
-    (identifier))))
+      (variable_name)
+      (variable_name)
+      (spread_element (variable_name)))
+    (variable_name))))
 
 ================================================
 Object destructuring patterns w/ default values
@@ -76,8 +76,8 @@ function a({b = true}, [c, d = false]) {}
 ---
 
 (program
-  (function (identifier)
+  (function (variable_name)
     (formal_parameters
-      (object_pattern (assignment_pattern (identifier) (true)))
-      (array_pattern (identifier) (assignment (identifier) (false))))
+      (object_pattern (assignment_pattern (shorthand_property_name) (true)))
+      (array_pattern (variable_name) (assignment (variable_name) (false))))
     (statement_block)))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -26,7 +26,7 @@ Template strings
 `multi
   ${2 + 2}
   hello
-  ${1 + 1,2 + 2}
+  ${1 + 1, 2 + 2}
   line`;
 
 `$$$$`;
@@ -39,11 +39,24 @@ Template strings
 ----
 
 (program
-  (expression_statement (template_string (template_chars)))
-  (expression_statement (template_string (template_chars)))
-  (expression_statement (template_string (template_chars) (template_substitution (math_op (number) (number))) (template_chars) (template_substitution (comma_op (math_op (number) (number)) (math_op (number) (number)))) (template_chars)))
-  (expression_statement (template_string (template_chars))) (expression_statement (template_string (template_chars) (template_substitution (number))))
-	(expression_statement (template_string (template_chars))) (expression_statement (template_string (template_chars) (template_substitution (function_call (member_access (identifier) (identifier)) (arguments (string)))) (template_chars) (template_substitution (identifier)) (template_chars))))
+  (expression_statement (template_string))
+  (expression_statement (template_string))
+  (expression_statement (template_string
+    (template_substitution (math_op
+      (number)
+      (number)))
+    (template_substitution (comma_op
+      (math_op (number) (number))
+      (math_op (number) (number))))))
+  (expression_statement (template_string))
+  (expression_statement (template_string
+    (template_substitution (number))))
+	(expression_statement (template_string))
+  (expression_statement (template_string
+    (template_substitution (function_call
+      (member_access (variable_name) (property_name))
+      (arguments (string))))
+    (template_substitution (variable_name)))))
 
 ============================================
 Function calls with template strings
@@ -54,7 +67,7 @@ f `hello`;
 ---
 
 (program
-  (expression_statement (function_call (identifier) (template_string (template_chars)))))
+  (expression_statement (function_call (variable_name) (template_string))))
 
 ============================================
 Numbers
@@ -90,9 +103,9 @@ $_;
 ---
 
 (program
-  (expression_statement (identifier))
-  (expression_statement (identifier))
-  (expression_statement (identifier)))
+  (expression_statement (variable_name))
+  (expression_statement (variable_name))
+  (expression_statement (variable_name)))
 
 ============================================
 Multi-line variable declarations
@@ -106,9 +119,9 @@ var a = b
 
 (program
   (variable_declaration
-    (variable_declarator (identifier) (identifier))
-    (variable_declarator (identifier) (identifier))
-    (variable_declarator (identifier) (identifier))))
+    (variable_declarator (variable_name) (variable_name))
+    (variable_declarator (variable_name) (variable_name))
+    (variable_declarator (variable_name) (variable_name))))
 
 ============================================
 Booleans
@@ -166,13 +179,13 @@ Objects
 (program
   (expression_statement (object))
   (expression_statement (object
-    (pair (identifier) (string))))
+    (pair (property_name) (string))))
   (expression_statement (object
-    (pair (identifier) (string))
-    (pair (string) (identifier))
+    (pair (property_name) (string))
+    (pair (string) (variable_name))
     (pair (number) (number))))
   (expression_statement (object
-    (pair (identifier) (identifier)))))
+    (pair (property_name) (variable_name)))))
 
 ============================================
 Objects with shorthand properties
@@ -185,11 +198,11 @@ y = {a,};
 
 (program
   (expression_statement (assignment
-    (identifier)
-    (object (identifier) (identifier) (reserved_identifier))))
+    (variable_name)
+    (object (shorthand_property_name) (shorthand_property_name) (shorthand_property_name))))
   (expression_statement (assignment
-    (identifier)
-    (object (identifier)))))
+    (variable_name)
+    (object (shorthand_property_name)))))
 
 ============================================
 Objects with method definitions
@@ -215,29 +228,29 @@ Objects with method definitions
 
 (program
   (expression_statement (object
-    (pair (identifier) (true))
+    (pair (property_name) (true))
     (method_definition
-      (identifier)
-      (formal_parameters (identifier) (identifier))
+      (property_name)
+      (formal_parameters (variable_name) (variable_name))
       (statement_block
-        (return_statement (math_op (identifier) (identifier)))))
+        (return_statement (math_op (variable_name) (variable_name)))))
     (method_definition
-      (identifier)
+      (property_name)
       (formal_parameters)
       (statement_block
-        (return_statement (identifier))))
+        (return_statement (variable_name))))
     (method_definition
-      (identifier)
-      (formal_parameters (identifier))
+      (property_name)
+      (formal_parameters (variable_name))
       (statement_block
-        (expression_statement (assignment (identifier) (identifier)))))
+        (expression_statement (assignment (variable_name) (variable_name)))))
     (method_definition
-      (identifier)
+      (property_name)
       (formal_parameters)
       (statement_block
-        (expression_statement (yield_expression (identifier)))))
+        (expression_statement (yield_expression (variable_name)))))
     (method_definition
-      (reserved_identifier)
+      (property_name)
       (formal_parameters)
       (statement_block
         (return_statement (number)))))))
@@ -261,13 +274,13 @@ Objects with reserved words for keys
 (program
   (expression_statement (object
     (pair
-      (reserved_identifier)
+      (property_name)
       (function (formal_parameters) (statement_block)))
     (pair
-      (reserved_identifier)
+      (property_name)
       (function (formal_parameters) (statement_block)))
-    (pair (identifier) (true))
-    (pair (reserved_identifier) (true)))))
+    (pair (property_name) (true))
+    (pair (property_name) (true)))))
 
 ============================================
 Classes
@@ -289,27 +302,27 @@ class Foo extends require('another-class') {
 
 (program
   (class
-    (identifier)
+    (variable_name)
     (class_body
       (method_definition
-        (identifier)
-        (formal_parameters (identifier))
-        (statement_block (return_statement (identifier))))
+        (property_name)
+        (formal_parameters (variable_name))
+        (statement_block (return_statement (variable_name))))
       (method_definition
-        (identifier)
-        (formal_parameters (identifier))
-        (statement_block (return_statement (identifier))))
+        (property_name)
+        (formal_parameters (variable_name))
+        (statement_block (return_statement (variable_name))))
       (method_definition
-        (identifier)
-        (formal_parameters (identifier))
-        (statement_block (return_statement (identifier))))))
+        (property_name)
+        (formal_parameters (variable_name))
+        (statement_block (return_statement (variable_name))))))
 
   (class
-    (identifier)
-    (class_heritage (function_call (identifier) (arguments (string))))
+    (variable_name)
+    (class_heritage (function_call (variable_name) (arguments (string))))
     (class_body
       (method_definition
-        (identifier)
+        (property_name)
         (formal_parameters)
         (statement_block
           (expression_statement (function_call (super) (arguments))))))))
@@ -326,9 +339,9 @@ class Foo {
 
 (program
   (class
-    (identifier)
+    (variable_name)
     (class_body
-      (public_field_definition (identifier) (number)))))
+      (public_field_definition (property_name) (number)))))
 
 ============================================
 Arrays
@@ -347,9 +360,9 @@ Arrays
   (expression_statement (array))
   (expression_statement (array (string)))
   (expression_statement (array (string)))
-  (expression_statement (array (string) (identifier)))
-  (expression_statement (array (identifier)))
-  (expression_statement (array (assignment (identifier) (number)))))
+  (expression_statement (array (string) (variable_name)))
+  (expression_statement (array (variable_name)))
+  (expression_statement (array (assignment (variable_name) (number)))))
 
 ============================================
 Functions
@@ -371,11 +384,11 @@ Functions
       (formal_parameters)
       (statement_block))
     (function
-      (formal_parameters (identifier) (identifier))
+      (formal_parameters (variable_name) (variable_name))
       (statement_block
-        (expression_statement (identifier))))
+        (expression_statement (variable_name))))
     (function
-      (identifier)
+      (variable_name)
       (formal_parameters)
       (statement_block)))))
 
@@ -394,18 +407,18 @@ a => 1;
 
 (program
   (expression_statement (arrow_function
-    (identifier)
+    (variable_name)
     (number)))
   (expression_statement (arrow_function
     (formal_parameters)
     (number)))
   (expression_statement (arrow_function
-    (formal_parameters (identifier) (identifier))
+    (formal_parameters (variable_name) (variable_name))
     (number)))
   (expression_statement (arrow_function
-    (formal_parameters (identifier) (identifier))
+    (formal_parameters (variable_name) (variable_name))
     (statement_block
-      (return_statement (identifier))))))
+      (return_statement (variable_name))))))
 
 ============================================
 Generator Functions
@@ -427,11 +440,11 @@ Generator Functions
       (formal_parameters)
       (statement_block))
     (generator_function
-      (identifier)
-      (formal_parameters (identifier) (identifier))
+      (variable_name)
+      (formal_parameters (variable_name) (variable_name))
       (statement_block
         (expression_statement (yield_expression))
-        (expression_statement (yield_expression (identifier))))))))
+        (expression_statement (yield_expression (variable_name))))))))
 
 ============================================
 Property access
@@ -444,9 +457,9 @@ x["some-string"];
 ---
 
 (program
-  (expression_statement (member_access (identifier) (identifier)))
-  (expression_statement (subscript_access (identifier) (identifier)))
-  (expression_statement (subscript_access (identifier) (string))))
+  (expression_statement (member_access (variable_name) (property_name)))
+  (expression_statement (subscript_access (variable_name) (variable_name)))
+  (expression_statement (subscript_access (variable_name) (string))))
 
 ============================================
 Chained Property access
@@ -464,12 +477,12 @@ return returned.promise()
       (function_call
         (member_access
           (function_call
-            (member_access (identifier) (identifier))
+            (member_access (variable_name) (property_name))
             (arguments))
-          (identifier))
-        (arguments (member_access (identifier) (identifier))))
-      (identifier))
-  (arguments (member_access (identifier) (identifier))))))
+          (property_name))
+        (arguments (member_access (variable_name) (property_name))))
+      (property_name))
+  (arguments (member_access (variable_name) (property_name))))))
 
 ============================================
 Chained callbacks
@@ -478,7 +491,9 @@ Chained callbacks
 return this.map(function (a) {
   return a.b;
 })
+
 // a comment
+
 .filter(function (c) {
   return c.d;
 })
@@ -490,14 +505,14 @@ return this.map(function (a) {
   (function_call
     (member_access
       (function_call
-        (member_access (this_expression) (identifier))
+        (member_access (this_expression) (property_name))
         (arguments
-          (function (formal_parameters (identifier)) (statement_block
-            (return_statement (member_access (identifier) (identifier)))))))
+          (function (formal_parameters (variable_name)) (statement_block
+            (return_statement (member_access (variable_name) (property_name)))))))
         (comment)
-      (identifier))
-      (arguments (function (formal_parameters (identifier)) (statement_block
-        (return_statement (member_access (identifier) (identifier)))))))))
+      (property_name))
+      (arguments (function (formal_parameters (variable_name)) (statement_block
+        (return_statement (member_access (variable_name) (property_name)))))))))
 
 ============================================
 Function calls
@@ -512,13 +527,13 @@ function(x, y) {
 
 (program
   (expression_statement (function_call
-    (member_access (identifier) (identifier))
-    (arguments (identifier) (string))))
+    (member_access (variable_name) (property_name))
+    (arguments (variable_name) (string))))
   (expression_statement (function_call
     (function
-      (formal_parameters (identifier) (identifier))
+      (formal_parameters (variable_name) (variable_name))
       (statement_block))
-    (arguments (identifier) (identifier)))))
+    (arguments (variable_name) (variable_name)))))
 
 ============================================
 Constructor calls
@@ -531,10 +546,10 @@ new Thing;
 
 (program
   (expression_statement (new_expression (function_call
-    (member_access (identifier) (identifier))
+    (member_access (variable_name) (property_name))
     (arguments (number) (string)))))
   (expression_statement (new_expression
-    (identifier))))
+    (variable_name))))
 
 ============================================
 Await Expressions
@@ -548,8 +563,8 @@ await asyncPromise;
 (program
   (expression_statement
     (await_expression
-      (function_call (identifier) (arguments))))
-  (expression_statement (await_expression (identifier))))
+      (function_call (variable_name) (arguments))))
+  (expression_statement (await_expression (variable_name))))
 
 ============================================
 Async Functions and Methods
@@ -572,25 +587,25 @@ async (a) => { return foo; };
 
 (program
   (function
-    (identifier)
+    (variable_name)
     (formal_parameters)
     (statement_block))
   (expression_statement
     (object
       (method_definition
-        (identifier)
+        (property_name)
         (formal_parameters)
         (statement_block))))
-  (class (identifier) (class_body
+  (class (variable_name) (class_body
     (method_definition
-      (identifier)
+      (property_name)
       (formal_parameters)
       (statement_block))))
   (expression_statement
     (arrow_function
-      (formal_parameters (identifier))
+      (formal_parameters (variable_name))
       (statement_block
-        (return_statement (identifier))))))
+        (return_statement (variable_name))))))
 
 ============================================
 Math operators
@@ -605,15 +620,15 @@ i + j * 3 - j % 5;
 ---
 
 (program
-  (expression_statement (math_op (identifier)))
-  (expression_statement (math_op (identifier)))
+  (expression_statement (math_op (variable_name)))
+  (expression_statement (math_op (variable_name)))
   (expression_statement (math_op
     (math_op
-      (identifier)
-      (math_op (identifier) (number)))
-    (math_op (identifier) (number))))
-  (expression_statement (math_op (identifier)))
-  (expression_statement (math_op (identifier))))
+      (variable_name)
+      (math_op (variable_name) (number)))
+    (math_op (variable_name) (number))))
+  (expression_statement (math_op (variable_name)))
+  (expression_statement (math_op (variable_name))))
 
 ============================================
 Boolean operators
@@ -626,15 +641,15 @@ i && j;
 ---
 
 (program
-  (expression_statement (bool_op (identifier) (identifier)))
-  (expression_statement (bool_op (identifier) (identifier)))
+  (expression_statement (bool_op (variable_name) (variable_name)))
+  (expression_statement (bool_op (variable_name) (variable_name)))
   (expression_statement (bool_op
     (bool_op
-      (bool_op (identifier))
-      (bool_op (identifier)))
+      (bool_op (variable_name))
+      (bool_op (variable_name)))
     (bool_op
-      (bool_op (identifier))
-      (bool_op (identifier))))))
+      (bool_op (variable_name))
+      (bool_op (variable_name))))))
 
 ============================================
 Bitwise operators
@@ -653,17 +668,17 @@ i | j;
 ---
 
 (program
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
   (expression_statement (bitwise_op
-    (bitwise_op (identifier))
-    (bitwise_op (identifier)))))
+    (bitwise_op (variable_name))
+    (bitwise_op (variable_name)))))
 
 ============================================
 Relational operators
@@ -681,14 +696,14 @@ x > y;
 ---
 
 (program
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier))))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name))))
 
 ==============================================
 Assignments
@@ -702,13 +717,13 @@ x["y"] = 0;
 
 (program
   (expression_statement (assignment
-    (identifier)
+    (variable_name)
     (number)))
   (expression_statement (assignment
-    (member_access (identifier) (identifier))
+    (member_access (variable_name) (property_name))
     (number)))
   (expression_statement (assignment
-    (subscript_access (identifier) (string))
+    (subscript_access (variable_name) (string))
     (number))))
 
 ==============================================
@@ -722,12 +737,12 @@ c = {d: (3, 4 + 5, 6)};
 
 (program
   (expression_statement (comma_op
-    (assignment (identifier) (number))
-    (assignment (identifier) (number))))
+    (assignment (variable_name) (number))
+    (assignment (variable_name) (number))))
   (expression_statement
-    (assignment (identifier) (object
+    (assignment (variable_name) (object
       (pair
-        (identifier)
+        (property_name)
         (comma_op (number) (comma_op (math_op (number) (number)) (number))))))))
 
 ==============================================
@@ -743,13 +758,13 @@ x.y = some.condition ?
 
 (program
   (expression_statement (ternary
-    (identifier) (identifier) (identifier)))
+    (variable_name) (variable_name) (variable_name)))
   (expression_statement (assignment
-    (member_access (identifier) (identifier))
+    (member_access (variable_name) (property_name))
     (ternary
-      (member_access (identifier) (identifier))
-      (member_access (identifier) (identifier))
-      (member_access (member_access (identifier) (identifier)) (identifier))))))
+      (member_access (variable_name) (property_name))
+      (member_access (variable_name) (property_name))
+      (member_access (member_access (variable_name) (property_name)) (property_name))))))
 
 ==============================================
 Type operators
@@ -761,8 +776,8 @@ x instanceof String;
 ---
 
 (program
-  (expression_statement (type_op (identifier)))
-  (expression_statement (type_op (identifier) (identifier))))
+  (expression_statement (type_op (variable_name)))
+  (expression_statement (type_op (variable_name) (variable_name))))
 
 ============================================
 The delete operator
@@ -775,10 +790,10 @@ true ? delete thing.prop : null;
 
 (program
   (expression_statement
-    (delete_op (subscript_access (identifier) (string))))
+    (delete_op (subscript_access (variable_name) (string))))
   (expression_statement
     (ternary (true)
-      (delete_op (member_access (identifier) (identifier)))
+      (delete_op (member_access (variable_name) (property_name)))
       (null))))
 
 ============================================
@@ -790,8 +805,8 @@ a = void b()
 ---
 
 (program (expression_statement (assignment
-  (identifier)
-  (void_op (function_call (identifier) (arguments))))))
+  (variable_name)
+  (void_op (function_call (variable_name) (arguments))))))
 
 ==============================================
 Math assignment operators
@@ -807,15 +822,15 @@ y.z *= 5;
 
 (program
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (math_assignment (variable_name) (number)))
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (math_assignment (variable_name) (number)))
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (math_assignment (variable_name) (number)))
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (math_assignment (variable_name) (number)))
   (expression_statement
-    (math_assignment (member_access (identifier) (identifier)) (number))))
+    (math_assignment (member_access (variable_name) (property_name)) (number))))
 
 ==============================================
 Operator precedence
@@ -831,26 +846,26 @@ typeof a == b && c instanceof d
 
 (program
   (expression_statement (bool_op
-    (rel_op (identifier) (identifier))
-    (rel_op (identifier) (identifier))))
+    (rel_op (variable_name) (variable_name))
+    (rel_op (variable_name) (variable_name))))
   (expression_statement (assignment
-    (member_access (identifier) (identifier))
-    (ternary (identifier) (identifier) (identifier))))
+    (member_access (variable_name) (property_name))
+    (ternary (variable_name) (variable_name) (variable_name))))
   (expression_statement (bool_op
     (bool_op
-      (identifier)
-      (function_call (identifier) (arguments (identifier))))
-    (identifier)))
+      (variable_name)
+      (function_call (variable_name) (arguments (variable_name))))
+    (variable_name)))
   (expression_statement (bool_op
     (bool_op
-      (identifier)
-      (new_expression (function_call (identifier) (arguments (identifier)))))
-    (identifier)))
+      (variable_name)
+      (new_expression (function_call (variable_name) (arguments (variable_name)))))
+    (variable_name)))
   (expression_statement (bool_op
     (rel_op
-      (type_op (identifier))
-      (identifier))
-    (type_op (identifier) (identifier)))))
+      (type_op (variable_name))
+      (variable_name))
+    (type_op (variable_name) (variable_name)))))
 
 ==============================================
 Simple JSX elements
@@ -863,13 +878,13 @@ b = <div>a <span>b</span> c</div>;
 
 (program
   (expression_statement (assignment
-    (identifier)
+    (variable_name)
     (jsx_self_closing_element
       (identifier)
       (jsx_attribute (identifier) (string))
       (jsx_attribute (identifier) (number)))))
   (expression_statement (assignment
-    (identifier)
+    (variable_name)
     (jsx_element
       (jsx_opening_element (identifier))
       (jsx_text)
@@ -891,20 +906,20 @@ h = <i>{...j}</i>
 
 (program
   (expression_statement (assignment
-    (identifier)
+    (variable_name)
     (jsx_element
       (jsx_opening_element (identifier)
         (jsx_attribute (identifier))
-        (jsx_attribute (identifier) (jsx_expression (identifier))))
+        (jsx_attribute (identifier) (jsx_expression (variable_name))))
       (jsx_text)
-      (jsx_expression (identifier))
+      (jsx_expression (variable_name))
       (jsx_text)
       (jsx_closing_element (identifier)))))
   (expression_statement (assignment
-    (identifier)
+    (variable_name)
     (jsx_element
       (jsx_opening_element (identifier))
-      (jsx_expression (spread_element (identifier)))
+      (jsx_expression (spread_element (variable_name)))
       (jsx_closing_element (identifier))))))
 
 
@@ -918,7 +933,7 @@ foo(...rest)
 
 (program
   (expression_statement
-    (function_call (identifier) (arguments (rest_argument (identifier))))))
+    (function_call (variable_name) (arguments (rest_argument (variable_name))))))
 
 ==============================================
 Math expressions
@@ -930,7 +945,7 @@ Math expressions
 
 (program
   (expression_statement
-    (math_op (math_op (identifier) (identifier)) (identifier))))
+    (math_op (math_op (variable_name) (variable_name)) (variable_name))))
 
 
 ==============================================
@@ -957,4 +972,8 @@ yield db.users.where('[endpoint+email]')
 (program
   (expression_statement
     (yield_expression
-      (function_call (member_access (member_access (identifier) (identifier)) (identifier)) (arguments (string))))))
+      (function_call
+        (member_access
+          (member_access (variable_name) (property_name))
+          (property_name))
+        (arguments (string))))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -54,9 +54,9 @@ Template strings
 	(expression_statement (template_string))
   (expression_statement (template_string
     (template_substitution (function_call
-      (member_access (variable_name) (property_name))
+      (member_access (identifier) (property_identifier))
       (arguments (string))))
-    (template_substitution (variable_name)))))
+    (template_substitution (identifier)))))
 
 ============================================
 Function calls with template strings
@@ -67,7 +67,7 @@ f `hello`;
 ---
 
 (program
-  (expression_statement (function_call (variable_name) (template_string))))
+  (expression_statement (function_call (identifier) (template_string))))
 
 ============================================
 Numbers
@@ -103,9 +103,9 @@ $_;
 ---
 
 (program
-  (expression_statement (variable_name))
-  (expression_statement (variable_name))
-  (expression_statement (variable_name)))
+  (expression_statement (identifier))
+  (expression_statement (identifier))
+  (expression_statement (identifier)))
 
 ============================================
 Multi-line variable declarations
@@ -119,9 +119,9 @@ var a = b
 
 (program
   (variable_declaration
-    (variable_declarator (variable_name) (variable_name))
-    (variable_declarator (variable_name) (variable_name))
-    (variable_declarator (variable_name) (variable_name))))
+    (variable_declarator (identifier) (identifier))
+    (variable_declarator (identifier) (identifier))
+    (variable_declarator (identifier) (identifier))))
 
 ============================================
 Booleans
@@ -179,13 +179,13 @@ Objects
 (program
   (expression_statement (object))
   (expression_statement (object
-    (pair (property_name) (string))))
+    (pair (property_identifier) (string))))
   (expression_statement (object
-    (pair (property_name) (string))
-    (pair (string) (variable_name))
+    (pair (property_identifier) (string))
+    (pair (string) (identifier))
     (pair (number) (number))))
   (expression_statement (object
-    (pair (property_name) (variable_name)))))
+    (pair (property_identifier) (identifier)))))
 
 ============================================
 Objects with shorthand properties
@@ -198,11 +198,11 @@ y = {a,};
 
 (program
   (expression_statement (assignment
-    (variable_name)
-    (object (shorthand_property_name) (shorthand_property_name) (shorthand_property_name))))
+    (identifier)
+    (object (shorthand_property_identifier) (shorthand_property_identifier) (shorthand_property_identifier))))
   (expression_statement (assignment
-    (variable_name)
-    (object (shorthand_property_name)))))
+    (identifier)
+    (object (shorthand_property_identifier)))))
 
 ============================================
 Objects with method definitions
@@ -228,29 +228,29 @@ Objects with method definitions
 
 (program
   (expression_statement (object
-    (pair (property_name) (true))
+    (pair (property_identifier) (true))
     (method_definition
-      (property_name)
-      (formal_parameters (variable_name) (variable_name))
+      (property_identifier)
+      (formal_parameters (identifier) (identifier))
       (statement_block
-        (return_statement (math_op (variable_name) (variable_name)))))
+        (return_statement (math_op (identifier) (identifier)))))
     (method_definition
-      (property_name)
+      (property_identifier)
       (formal_parameters)
       (statement_block
-        (return_statement (variable_name))))
+        (return_statement (identifier))))
     (method_definition
-      (property_name)
-      (formal_parameters (variable_name))
+      (property_identifier)
+      (formal_parameters (identifier))
       (statement_block
-        (expression_statement (assignment (variable_name) (variable_name)))))
+        (expression_statement (assignment (identifier) (identifier)))))
     (method_definition
-      (property_name)
+      (property_identifier)
       (formal_parameters)
       (statement_block
-        (expression_statement (yield_expression (variable_name)))))
+        (expression_statement (yield_expression (identifier)))))
     (method_definition
-      (property_name)
+      (property_identifier)
       (formal_parameters)
       (statement_block
         (return_statement (number)))))))
@@ -274,13 +274,13 @@ Objects with reserved words for keys
 (program
   (expression_statement (object
     (pair
-      (property_name)
+      (property_identifier)
       (function (formal_parameters) (statement_block)))
     (pair
-      (property_name)
+      (property_identifier)
       (function (formal_parameters) (statement_block)))
-    (pair (property_name) (true))
-    (pair (property_name) (true)))))
+    (pair (property_identifier) (true))
+    (pair (property_identifier) (true)))))
 
 ============================================
 Classes
@@ -302,27 +302,27 @@ class Foo extends require('another-class') {
 
 (program
   (class
-    (variable_name)
+    (identifier)
     (class_body
       (method_definition
-        (property_name)
-        (formal_parameters (variable_name))
-        (statement_block (return_statement (variable_name))))
+        (property_identifier)
+        (formal_parameters (identifier))
+        (statement_block (return_statement (identifier))))
       (method_definition
-        (property_name)
-        (formal_parameters (variable_name))
-        (statement_block (return_statement (variable_name))))
+        (property_identifier)
+        (formal_parameters (identifier))
+        (statement_block (return_statement (identifier))))
       (method_definition
-        (property_name)
-        (formal_parameters (variable_name))
-        (statement_block (return_statement (variable_name))))))
+        (property_identifier)
+        (formal_parameters (identifier))
+        (statement_block (return_statement (identifier))))))
 
   (class
-    (variable_name)
-    (class_heritage (function_call (variable_name) (arguments (string))))
+    (identifier)
+    (class_heritage (function_call (identifier) (arguments (string))))
     (class_body
       (method_definition
-        (property_name)
+        (property_identifier)
         (formal_parameters)
         (statement_block
           (expression_statement (function_call (super) (arguments))))))))
@@ -339,9 +339,9 @@ class Foo {
 
 (program
   (class
-    (variable_name)
+    (identifier)
     (class_body
-      (public_field_definition (property_name) (number)))))
+      (public_field_definition (property_identifier) (number)))))
 
 ============================================
 Arrays
@@ -360,9 +360,9 @@ Arrays
   (expression_statement (array))
   (expression_statement (array (string)))
   (expression_statement (array (string)))
-  (expression_statement (array (string) (variable_name)))
-  (expression_statement (array (variable_name)))
-  (expression_statement (array (assignment (variable_name) (number)))))
+  (expression_statement (array (string) (identifier)))
+  (expression_statement (array (identifier)))
+  (expression_statement (array (assignment (identifier) (number)))))
 
 ============================================
 Functions
@@ -384,11 +384,11 @@ Functions
       (formal_parameters)
       (statement_block))
     (function
-      (formal_parameters (variable_name) (variable_name))
+      (formal_parameters (identifier) (identifier))
       (statement_block
-        (expression_statement (variable_name))))
+        (expression_statement (identifier))))
     (function
-      (variable_name)
+      (identifier)
       (formal_parameters)
       (statement_block)))))
 
@@ -407,18 +407,18 @@ a => 1;
 
 (program
   (expression_statement (arrow_function
-    (variable_name)
+    (identifier)
     (number)))
   (expression_statement (arrow_function
     (formal_parameters)
     (number)))
   (expression_statement (arrow_function
-    (formal_parameters (variable_name) (variable_name))
+    (formal_parameters (identifier) (identifier))
     (number)))
   (expression_statement (arrow_function
-    (formal_parameters (variable_name) (variable_name))
+    (formal_parameters (identifier) (identifier))
     (statement_block
-      (return_statement (variable_name))))))
+      (return_statement (identifier))))))
 
 ============================================
 Generator Functions
@@ -440,11 +440,11 @@ Generator Functions
       (formal_parameters)
       (statement_block))
     (generator_function
-      (variable_name)
-      (formal_parameters (variable_name) (variable_name))
+      (identifier)
+      (formal_parameters (identifier) (identifier))
       (statement_block
         (expression_statement (yield_expression))
-        (expression_statement (yield_expression (variable_name))))))))
+        (expression_statement (yield_expression (identifier))))))))
 
 ============================================
 Property access
@@ -457,9 +457,9 @@ x["some-string"];
 ---
 
 (program
-  (expression_statement (member_access (variable_name) (property_name)))
-  (expression_statement (subscript_access (variable_name) (variable_name)))
-  (expression_statement (subscript_access (variable_name) (string))))
+  (expression_statement (member_access (identifier) (property_identifier)))
+  (expression_statement (subscript_access (identifier) (identifier)))
+  (expression_statement (subscript_access (identifier) (string))))
 
 ============================================
 Chained Property access
@@ -477,12 +477,12 @@ return returned.promise()
       (function_call
         (member_access
           (function_call
-            (member_access (variable_name) (property_name))
+            (member_access (identifier) (property_identifier))
             (arguments))
-          (property_name))
-        (arguments (member_access (variable_name) (property_name))))
-      (property_name))
-  (arguments (member_access (variable_name) (property_name))))))
+          (property_identifier))
+        (arguments (member_access (identifier) (property_identifier))))
+      (property_identifier))
+  (arguments (member_access (identifier) (property_identifier))))))
 
 ============================================
 Chained callbacks
@@ -505,14 +505,14 @@ return this.map(function (a) {
   (function_call
     (member_access
       (function_call
-        (member_access (this_expression) (property_name))
+        (member_access (this_expression) (property_identifier))
         (arguments
-          (function (formal_parameters (variable_name)) (statement_block
-            (return_statement (member_access (variable_name) (property_name)))))))
+          (function (formal_parameters (identifier)) (statement_block
+            (return_statement (member_access (identifier) (property_identifier)))))))
         (comment)
-      (property_name))
-      (arguments (function (formal_parameters (variable_name)) (statement_block
-        (return_statement (member_access (variable_name) (property_name)))))))))
+      (property_identifier))
+      (arguments (function (formal_parameters (identifier)) (statement_block
+        (return_statement (member_access (identifier) (property_identifier)))))))))
 
 ============================================
 Function calls
@@ -527,13 +527,13 @@ function(x, y) {
 
 (program
   (expression_statement (function_call
-    (member_access (variable_name) (property_name))
-    (arguments (variable_name) (string))))
+    (member_access (identifier) (property_identifier))
+    (arguments (identifier) (string))))
   (expression_statement (function_call
     (function
-      (formal_parameters (variable_name) (variable_name))
+      (formal_parameters (identifier) (identifier))
       (statement_block))
-    (arguments (variable_name) (variable_name)))))
+    (arguments (identifier) (identifier)))))
 
 ============================================
 Constructor calls
@@ -546,10 +546,10 @@ new Thing;
 
 (program
   (expression_statement (new_expression (function_call
-    (member_access (variable_name) (property_name))
+    (member_access (identifier) (property_identifier))
     (arguments (number) (string)))))
   (expression_statement (new_expression
-    (variable_name))))
+    (identifier))))
 
 ============================================
 Await Expressions
@@ -563,8 +563,8 @@ await asyncPromise;
 (program
   (expression_statement
     (await_expression
-      (function_call (variable_name) (arguments))))
-  (expression_statement (await_expression (variable_name))))
+      (function_call (identifier) (arguments))))
+  (expression_statement (await_expression (identifier))))
 
 ============================================
 Async Functions and Methods
@@ -587,25 +587,25 @@ async (a) => { return foo; };
 
 (program
   (function
-    (variable_name)
+    (identifier)
     (formal_parameters)
     (statement_block))
   (expression_statement
     (object
       (method_definition
-        (property_name)
+        (property_identifier)
         (formal_parameters)
         (statement_block))))
-  (class (variable_name) (class_body
+  (class (identifier) (class_body
     (method_definition
-      (property_name)
+      (property_identifier)
       (formal_parameters)
       (statement_block))))
   (expression_statement
     (arrow_function
-      (formal_parameters (variable_name))
+      (formal_parameters (identifier))
       (statement_block
-        (return_statement (variable_name))))))
+        (return_statement (identifier))))))
 
 ============================================
 Math operators
@@ -620,15 +620,15 @@ i + j * 3 - j % 5;
 ---
 
 (program
-  (expression_statement (math_op (variable_name)))
-  (expression_statement (math_op (variable_name)))
+  (expression_statement (math_op (identifier)))
+  (expression_statement (math_op (identifier)))
   (expression_statement (math_op
     (math_op
-      (variable_name)
-      (math_op (variable_name) (number)))
-    (math_op (variable_name) (number))))
-  (expression_statement (math_op (variable_name)))
-  (expression_statement (math_op (variable_name))))
+      (identifier)
+      (math_op (identifier) (number)))
+    (math_op (identifier) (number))))
+  (expression_statement (math_op (identifier)))
+  (expression_statement (math_op (identifier))))
 
 ============================================
 Boolean operators
@@ -641,15 +641,15 @@ i && j;
 ---
 
 (program
-  (expression_statement (bool_op (variable_name) (variable_name)))
-  (expression_statement (bool_op (variable_name) (variable_name)))
+  (expression_statement (bool_op (identifier) (identifier)))
+  (expression_statement (bool_op (identifier) (identifier)))
   (expression_statement (bool_op
     (bool_op
-      (bool_op (variable_name))
-      (bool_op (variable_name)))
+      (bool_op (identifier))
+      (bool_op (identifier)))
     (bool_op
-      (bool_op (variable_name))
-      (bool_op (variable_name))))))
+      (bool_op (identifier))
+      (bool_op (identifier))))))
 
 ============================================
 Bitwise operators
@@ -668,17 +668,17 @@ i | j;
 ---
 
 (program
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
   (expression_statement (bitwise_op
-    (bitwise_op (variable_name))
-    (bitwise_op (variable_name)))))
+    (bitwise_op (identifier))
+    (bitwise_op (identifier)))))
 
 ============================================
 Relational operators
@@ -696,14 +696,14 @@ x > y;
 ---
 
 (program
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name))))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier))))
 
 ==============================================
 Assignments
@@ -717,13 +717,13 @@ x["y"] = 0;
 
 (program
   (expression_statement (assignment
-    (variable_name)
+    (identifier)
     (number)))
   (expression_statement (assignment
-    (member_access (variable_name) (property_name))
+    (member_access (identifier) (property_identifier))
     (number)))
   (expression_statement (assignment
-    (subscript_access (variable_name) (string))
+    (subscript_access (identifier) (string))
     (number))))
 
 ==============================================
@@ -737,12 +737,12 @@ c = {d: (3, 4 + 5, 6)};
 
 (program
   (expression_statement (comma_op
-    (assignment (variable_name) (number))
-    (assignment (variable_name) (number))))
+    (assignment (identifier) (number))
+    (assignment (identifier) (number))))
   (expression_statement
-    (assignment (variable_name) (object
+    (assignment (identifier) (object
       (pair
-        (property_name)
+        (property_identifier)
         (comma_op (number) (comma_op (math_op (number) (number)) (number))))))))
 
 ==============================================
@@ -758,13 +758,13 @@ x.y = some.condition ?
 
 (program
   (expression_statement (ternary
-    (variable_name) (variable_name) (variable_name)))
+    (identifier) (identifier) (identifier)))
   (expression_statement (assignment
-    (member_access (variable_name) (property_name))
+    (member_access (identifier) (property_identifier))
     (ternary
-      (member_access (variable_name) (property_name))
-      (member_access (variable_name) (property_name))
-      (member_access (member_access (variable_name) (property_name)) (property_name))))))
+      (member_access (identifier) (property_identifier))
+      (member_access (identifier) (property_identifier))
+      (member_access (member_access (identifier) (property_identifier)) (property_identifier))))))
 
 ==============================================
 Type operators
@@ -776,8 +776,8 @@ x instanceof String;
 ---
 
 (program
-  (expression_statement (type_op (variable_name)))
-  (expression_statement (type_op (variable_name) (variable_name))))
+  (expression_statement (type_op (identifier)))
+  (expression_statement (type_op (identifier) (identifier))))
 
 ============================================
 The delete operator
@@ -790,10 +790,10 @@ true ? delete thing.prop : null;
 
 (program
   (expression_statement
-    (delete_op (subscript_access (variable_name) (string))))
+    (delete_op (subscript_access (identifier) (string))))
   (expression_statement
     (ternary (true)
-      (delete_op (member_access (variable_name) (property_name)))
+      (delete_op (member_access (identifier) (property_identifier)))
       (null))))
 
 ============================================
@@ -805,8 +805,8 @@ a = void b()
 ---
 
 (program (expression_statement (assignment
-  (variable_name)
-  (void_op (function_call (variable_name) (arguments))))))
+  (identifier)
+  (void_op (function_call (identifier) (arguments))))))
 
 ==============================================
 Math assignment operators
@@ -822,15 +822,15 @@ y.z *= 5;
 
 (program
   (expression_statement
-    (math_assignment (variable_name) (number)))
+    (math_assignment (identifier) (number)))
   (expression_statement
-    (math_assignment (variable_name) (number)))
+    (math_assignment (identifier) (number)))
   (expression_statement
-    (math_assignment (variable_name) (number)))
+    (math_assignment (identifier) (number)))
   (expression_statement
-    (math_assignment (variable_name) (number)))
+    (math_assignment (identifier) (number)))
   (expression_statement
-    (math_assignment (member_access (variable_name) (property_name)) (number))))
+    (math_assignment (member_access (identifier) (property_identifier)) (number))))
 
 ==============================================
 Operator precedence
@@ -846,26 +846,26 @@ typeof a == b && c instanceof d
 
 (program
   (expression_statement (bool_op
-    (rel_op (variable_name) (variable_name))
-    (rel_op (variable_name) (variable_name))))
+    (rel_op (identifier) (identifier))
+    (rel_op (identifier) (identifier))))
   (expression_statement (assignment
-    (member_access (variable_name) (property_name))
-    (ternary (variable_name) (variable_name) (variable_name))))
+    (member_access (identifier) (property_identifier))
+    (ternary (identifier) (identifier) (identifier))))
   (expression_statement (bool_op
     (bool_op
-      (variable_name)
-      (function_call (variable_name) (arguments (variable_name))))
-    (variable_name)))
+      (identifier)
+      (function_call (identifier) (arguments (identifier))))
+    (identifier)))
   (expression_statement (bool_op
     (bool_op
-      (variable_name)
-      (new_expression (function_call (variable_name) (arguments (variable_name)))))
-    (variable_name)))
+      (identifier)
+      (new_expression (function_call (identifier) (arguments (identifier)))))
+    (identifier)))
   (expression_statement (bool_op
     (rel_op
-      (type_op (variable_name))
-      (variable_name))
-    (type_op (variable_name) (variable_name)))))
+      (type_op (identifier))
+      (identifier))
+    (type_op (identifier) (identifier)))))
 
 ==============================================
 Simple JSX elements
@@ -878,13 +878,13 @@ b = <div>a <span>b</span> c</div>;
 
 (program
   (expression_statement (assignment
-    (variable_name)
+    (identifier)
     (jsx_self_closing_element
       (identifier)
-      (jsx_attribute (identifier) (string))
-      (jsx_attribute (identifier) (number)))))
+      (jsx_attribute (property_identifier) (string))
+      (jsx_attribute (property_identifier) (number)))))
   (expression_statement (assignment
-    (variable_name)
+    (identifier)
     (jsx_element
       (jsx_opening_element (identifier))
       (jsx_text)
@@ -906,20 +906,20 @@ h = <i>{...j}</i>
 
 (program
   (expression_statement (assignment
-    (variable_name)
+    (identifier)
     (jsx_element
       (jsx_opening_element (identifier)
-        (jsx_attribute (identifier))
-        (jsx_attribute (identifier) (jsx_expression (variable_name))))
+        (jsx_attribute (property_identifier))
+        (jsx_attribute (property_identifier) (jsx_expression (identifier))))
       (jsx_text)
-      (jsx_expression (variable_name))
+      (jsx_expression (identifier))
       (jsx_text)
       (jsx_closing_element (identifier)))))
   (expression_statement (assignment
-    (variable_name)
+    (identifier)
     (jsx_element
       (jsx_opening_element (identifier))
-      (jsx_expression (spread_element (variable_name)))
+      (jsx_expression (spread_element (identifier)))
       (jsx_closing_element (identifier))))))
 
 
@@ -933,7 +933,7 @@ foo(...rest)
 
 (program
   (expression_statement
-    (function_call (variable_name) (arguments (rest_argument (variable_name))))))
+    (function_call (identifier) (arguments (rest_argument (identifier))))))
 
 ==============================================
 Math expressions
@@ -945,8 +945,7 @@ Math expressions
 
 (program
   (expression_statement
-    (math_op (math_op (variable_name) (variable_name)) (variable_name))))
-
+    (math_op (math_op (identifier) (identifier)) (identifier))))
 
 ==============================================
 Non-breaking spaces as whitespace
@@ -974,6 +973,6 @@ yield db.users.where('[endpoint+email]')
     (yield_expression
       (function_call
         (member_access
-          (member_access (variable_name) (property_name))
-          (property_name))
+          (member_access (identifier) (property_identifier))
+          (property_identifier))
         (arguments (string))))))

--- a/corpus/semicolon_insertion.txt
+++ b/corpus/semicolon_insertion.txt
@@ -12,11 +12,11 @@ if (a) {
 ---
 
 (program
-  (if_statement (identifier) (statement_block
-    (variable_declaration (variable_declarator (identifier) (identifier)))
-    (expression_statement (function_call (identifier) (arguments)))
-    (expression_statement (function_call (identifier) (arguments)))
-    (return_statement (identifier)))))
+  (if_statement (variable_name) (statement_block
+    (variable_declaration (variable_declarator (variable_name) (variable_name)))
+    (expression_statement (function_call (variable_name) (arguments)))
+    (expression_statement (function_call (variable_name) (arguments)))
+    (return_statement (variable_name)))))
 
 ==========================================
 property access across lines
@@ -30,8 +30,8 @@ object
 
 (program (expression_statement
   (member_access
-    (member_access (identifier) (identifier))
-    (identifier))))
+    (member_access (variable_name) (property_name))
+    (property_name))))
 
 ===========================================
 indented code after blocks
@@ -44,10 +44,10 @@ indented code after blocks
 
 (program
   (function
-    (identifier)
+    (variable_name)
     (formal_parameters)
     (statement_block))
-  (return_statement (identifier)))
+  (return_statement (variable_name)))
 
 ================================================
 operator expressions split across lines
@@ -72,12 +72,12 @@ a
 ---
 
 (program
-  (expression_statement (ternary (identifier) (identifier) (identifier)))
-  (expression_statement (bool_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (identifier))
-  (expression_statement (bool_op (identifier)))
+  (expression_statement (ternary (variable_name) (variable_name) (variable_name)))
+  (expression_statement (bool_op (variable_name) (variable_name)))
+  (expression_statement (bitwise_op (variable_name) (variable_name)))
+  (expression_statement (rel_op (variable_name) (variable_name)))
+  (expression_statement (variable_name))
+  (expression_statement (bool_op (variable_name)))
   (comment))
 
 ================================================
@@ -105,21 +105,21 @@ a
 ---
 
 (program
-  (expression_statement (identifier))
-  (expression_statement (identifier))
+  (expression_statement (variable_name))
+  (expression_statement (variable_name))
 
-  (expression_statement (type_op (identifier) (identifier)))
+  (expression_statement (type_op (variable_name) (variable_name)))
 
-  (expression_statement (identifier))
-  (expression_statement (identifier))
+  (expression_statement (variable_name))
+  (expression_statement (variable_name))
 
-  (expression_statement (identifier))
-  (expression_statement (identifier))
+  (expression_statement (variable_name))
+  (expression_statement (variable_name))
 
-  (expression_statement (type_op (identifier) (identifier)))
+  (expression_statement (type_op (variable_name) (variable_name)))
 
-  (expression_statement (identifier))
-  (expression_statement (identifier)))
+  (expression_statement (variable_name))
+  (expression_statement (variable_name)))
 
 ===========================================
 Single-line if/else statements
@@ -130,9 +130,9 @@ if (a) {b} else {c}
 ---
 
 (program
-  (if_statement (identifier)
-    (statement_block (expression_statement (identifier)))
-    (statement_block (expression_statement (identifier)))))
+  (if_statement (variable_name)
+    (statement_block (expression_statement (variable_name)))
+    (statement_block (expression_statement (variable_name)))))
 
 ===========================================
 single-line blocks without semicolons
@@ -144,10 +144,10 @@ function c() {return d}
 ---
 
 (program
-  (function (identifier) (formal_parameters) (statement_block
-    (expression_statement (identifier))))
-  (function (identifier) (formal_parameters) (statement_block
-    (return_statement (identifier)))))
+  (function (variable_name) (formal_parameters) (statement_block
+    (expression_statement (variable_name))))
+  (function (variable_name) (formal_parameters) (statement_block
+    (return_statement (variable_name)))))
 
 ==============================================
 Multi-line chained expressions in var declarations
@@ -161,15 +161,15 @@ var a = new A()
 
 (program
   (variable_declaration (variable_declarator
-    (identifier)
+    (variable_name)
     (new_expression (function_call
       (member_access
         (function_call
           (member_access
-            (function_call (identifier) (arguments))
-            (identifier))
-          (arguments (object (pair (identifier) (string)))))
-        (identifier))
+            (function_call (variable_name) (arguments))
+            (property_name))
+          (arguments (object (pair (property_name) (string)))))
+        (property_name))
       (arguments))))))
 
 ==============================================
@@ -187,28 +187,28 @@ if (p) { var q }
 ---
 
 (program
-  (if_statement (identifier) (statement_block
+  (if_statement (variable_name) (statement_block
     (if_statement
-      (identifier)
-      (return_statement (identifier)))))
-  (if_statement (identifier) (statement_block
+      (variable_name)
+      (return_statement (variable_name)))))
+  (if_statement (variable_name) (statement_block
     (for_statement
       (break_statement))))
-  (if_statement (identifier) (statement_block
-    (for_in_statement (identifier) (identifier)
+  (if_statement (variable_name) (statement_block
+    (for_in_statement (variable_name) (variable_name)
       (break_statement))))
-  (if_statement (identifier) (statement_block
-    (for_of_statement (identifier) (identifier)
+  (if_statement (variable_name) (statement_block
+    (for_of_statement (variable_name) (variable_name)
       (continue_statement))))
-  (if_statement (identifier) (statement_block
-    (while_statement (identifier)
+  (if_statement (variable_name) (statement_block
+    (while_statement (variable_name)
       (break_statement))))
-  (if_statement (identifier) (statement_block
+  (if_statement (variable_name) (statement_block
     (do_statement
-      (statement_block (expression_statement (identifier)))
-      (identifier))))
-  (if_statement (identifier) (statement_block
-    (variable_declaration (variable_declarator (identifier))))))
+      (statement_block (expression_statement (variable_name)))
+      (variable_name))))
+  (if_statement (variable_name) (statement_block
+    (variable_declaration (variable_declarator (variable_name))))))
 
 =====================================================
 Single-line declarations without semicolons
@@ -218,8 +218,8 @@ function a () { function b () {} function *c () {} class D {} return }
 ---
 
 (program
-  (function (identifier) (formal_parameters) (statement_block
-    (function (identifier) (formal_parameters) (statement_block))
-    (generator_function (identifier) (formal_parameters) (statement_block))
-    (class (identifier) (class_body))
+  (function (variable_name) (formal_parameters) (statement_block
+    (function (variable_name) (formal_parameters) (statement_block))
+    (generator_function (variable_name) (formal_parameters) (statement_block))
+    (class (variable_name) (class_body))
     (return_statement))))

--- a/corpus/semicolon_insertion.txt
+++ b/corpus/semicolon_insertion.txt
@@ -12,11 +12,11 @@ if (a) {
 ---
 
 (program
-  (if_statement (variable_name) (statement_block
-    (variable_declaration (variable_declarator (variable_name) (variable_name)))
-    (expression_statement (function_call (variable_name) (arguments)))
-    (expression_statement (function_call (variable_name) (arguments)))
-    (return_statement (variable_name)))))
+  (if_statement (identifier) (statement_block
+    (variable_declaration (variable_declarator (identifier) (identifier)))
+    (expression_statement (function_call (identifier) (arguments)))
+    (expression_statement (function_call (identifier) (arguments)))
+    (return_statement (identifier)))))
 
 ==========================================
 property access across lines
@@ -30,8 +30,8 @@ object
 
 (program (expression_statement
   (member_access
-    (member_access (variable_name) (property_name))
-    (property_name))))
+    (member_access (identifier) (property_identifier))
+    (property_identifier))))
 
 ===========================================
 indented code after blocks
@@ -44,10 +44,10 @@ indented code after blocks
 
 (program
   (function
-    (variable_name)
+    (identifier)
     (formal_parameters)
     (statement_block))
-  (return_statement (variable_name)))
+  (return_statement (identifier)))
 
 ================================================
 operator expressions split across lines
@@ -72,12 +72,12 @@ a
 ---
 
 (program
-  (expression_statement (ternary (variable_name) (variable_name) (variable_name)))
-  (expression_statement (bool_op (variable_name) (variable_name)))
-  (expression_statement (bitwise_op (variable_name) (variable_name)))
-  (expression_statement (rel_op (variable_name) (variable_name)))
-  (expression_statement (variable_name))
-  (expression_statement (bool_op (variable_name)))
+  (expression_statement (ternary (identifier) (identifier) (identifier)))
+  (expression_statement (bool_op (identifier) (identifier)))
+  (expression_statement (bitwise_op (identifier) (identifier)))
+  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (identifier))
+  (expression_statement (bool_op (identifier)))
   (comment))
 
 ================================================
@@ -105,21 +105,21 @@ a
 ---
 
 (program
-  (expression_statement (variable_name))
-  (expression_statement (variable_name))
+  (expression_statement (identifier))
+  (expression_statement (identifier))
 
-  (expression_statement (type_op (variable_name) (variable_name)))
+  (expression_statement (type_op (identifier) (identifier)))
 
-  (expression_statement (variable_name))
-  (expression_statement (variable_name))
+  (expression_statement (identifier))
+  (expression_statement (identifier))
 
-  (expression_statement (variable_name))
-  (expression_statement (variable_name))
+  (expression_statement (identifier))
+  (expression_statement (identifier))
 
-  (expression_statement (type_op (variable_name) (variable_name)))
+  (expression_statement (type_op (identifier) (identifier)))
 
-  (expression_statement (variable_name))
-  (expression_statement (variable_name)))
+  (expression_statement (identifier))
+  (expression_statement (identifier)))
 
 ===========================================
 Single-line if/else statements
@@ -130,9 +130,9 @@ if (a) {b} else {c}
 ---
 
 (program
-  (if_statement (variable_name)
-    (statement_block (expression_statement (variable_name)))
-    (statement_block (expression_statement (variable_name)))))
+  (if_statement (identifier)
+    (statement_block (expression_statement (identifier)))
+    (statement_block (expression_statement (identifier)))))
 
 ===========================================
 single-line blocks without semicolons
@@ -144,10 +144,10 @@ function c() {return d}
 ---
 
 (program
-  (function (variable_name) (formal_parameters) (statement_block
-    (expression_statement (variable_name))))
-  (function (variable_name) (formal_parameters) (statement_block
-    (return_statement (variable_name)))))
+  (function (identifier) (formal_parameters) (statement_block
+    (expression_statement (identifier))))
+  (function (identifier) (formal_parameters) (statement_block
+    (return_statement (identifier)))))
 
 ==============================================
 Multi-line chained expressions in var declarations
@@ -161,15 +161,15 @@ var a = new A()
 
 (program
   (variable_declaration (variable_declarator
-    (variable_name)
+    (identifier)
     (new_expression (function_call
       (member_access
         (function_call
           (member_access
-            (function_call (variable_name) (arguments))
-            (property_name))
-          (arguments (object (pair (property_name) (string)))))
-        (property_name))
+            (function_call (identifier) (arguments))
+            (property_identifier))
+          (arguments (object (pair (property_identifier) (string)))))
+        (property_identifier))
       (arguments))))))
 
 ==============================================
@@ -187,28 +187,28 @@ if (p) { var q }
 ---
 
 (program
-  (if_statement (variable_name) (statement_block
+  (if_statement (identifier) (statement_block
     (if_statement
-      (variable_name)
-      (return_statement (variable_name)))))
-  (if_statement (variable_name) (statement_block
+      (identifier)
+      (return_statement (identifier)))))
+  (if_statement (identifier) (statement_block
     (for_statement
       (break_statement))))
-  (if_statement (variable_name) (statement_block
-    (for_in_statement (variable_name) (variable_name)
+  (if_statement (identifier) (statement_block
+    (for_in_statement (identifier) (identifier)
       (break_statement))))
-  (if_statement (variable_name) (statement_block
-    (for_of_statement (variable_name) (variable_name)
+  (if_statement (identifier) (statement_block
+    (for_of_statement (identifier) (identifier)
       (continue_statement))))
-  (if_statement (variable_name) (statement_block
-    (while_statement (variable_name)
+  (if_statement (identifier) (statement_block
+    (while_statement (identifier)
       (break_statement))))
-  (if_statement (variable_name) (statement_block
+  (if_statement (identifier) (statement_block
     (do_statement
-      (statement_block (expression_statement (variable_name)))
-      (variable_name))))
-  (if_statement (variable_name) (statement_block
-    (variable_declaration (variable_declarator (variable_name))))))
+      (statement_block (expression_statement (identifier)))
+      (identifier))))
+  (if_statement (identifier) (statement_block
+    (variable_declaration (variable_declarator (identifier))))))
 
 =====================================================
 Single-line declarations without semicolons
@@ -218,8 +218,8 @@ function a () { function b () {} function *c () {} class D {} return }
 ---
 
 (program
-  (function (variable_name) (formal_parameters) (statement_block
-    (function (variable_name) (formal_parameters) (statement_block))
-    (generator_function (variable_name) (formal_parameters) (statement_block))
-    (class (variable_name) (class_body))
+  (function (identifier) (formal_parameters) (statement_block
+    (function (identifier) (formal_parameters) (statement_block))
+    (generator_function (identifier) (formal_parameters) (statement_block))
+    (class (identifier) (class_body))
     (return_statement))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -16,23 +16,23 @@ import { member1 , member2 as alias2, } from "module-name";
 
 (program
   (import_statement
-    (import_clause (variable_name)) (string))
+    (import_clause (identifier)) (string))
   (import_statement
-    (import_clause (namespace_import (variable_name))) (string))
+    (import_clause (namespace_import (identifier))) (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (variable_name)))) (string))
+    (import_clause (named_imports (import_specifier (identifier)))) (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (variable_name)) (import_specifier (variable_name)))) (string))
+    (import_clause (named_imports (import_specifier (identifier)) (import_specifier (identifier)))) (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (variable_name)) (import_specifier (variable_name) (variable_name)))) (string))
+    (import_clause (named_imports (import_specifier (identifier)) (import_specifier (identifier) (identifier)))) (string))
   (import_statement
-    (import_clause (variable_name) (named_imports (import_specifier (variable_name)) (import_specifier (variable_name) (variable_name)))) (string))
+    (import_clause (identifier) (named_imports (import_specifier (identifier)) (import_specifier (identifier) (identifier)))) (string))
   (import_statement
-    (import_clause (variable_name) (namespace_import (variable_name))) (string))
+    (import_clause (identifier) (namespace_import (identifier))) (string))
   (import_statement
     (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (variable_name)) (import_specifier (variable_name) (variable_name)))) (string)))
+    (import_clause (named_imports (import_specifier (identifier)) (import_specifier (identifier) (identifier)))) (string)))
 
 ============================================
 Exports
@@ -57,47 +57,47 @@ export { import1 as name1, import2 as name2, nameN } from 'foo';
 (program
   (export_statement
     (export_clause
-      (export_specifier (variable_name))
-      (export_specifier (variable_name))
-      (export_specifier (variable_name))
-      (export_specifier (variable_name))))
+      (export_specifier (identifier))
+      (export_specifier (identifier))
+      (export_specifier (identifier))
+      (export_specifier (identifier))))
   (export_statement
     (export_clause
-      (export_specifier (variable_name) (variable_name))
-      (export_specifier (variable_name) (variable_name))
-      (export_specifier (variable_name))))
+      (export_specifier (identifier) (identifier))
+      (export_specifier (identifier) (identifier))
+      (export_specifier (identifier))))
   (export_statement
     (lexical_declaration
-      (variable_declarator (variable_name))
-      (variable_declarator (variable_name))
-      (variable_declarator (variable_name))))
+      (variable_declarator (identifier))
+      (variable_declarator (identifier))
+      (variable_declarator (identifier))))
   (export_statement
     (lexical_declaration
-      (variable_declarator (variable_name) (variable_name))
-      (variable_declarator (variable_name) (variable_name))
-      (variable_declarator (variable_name))
-      (variable_declarator (variable_name))))
+      (variable_declarator (identifier) (identifier))
+      (variable_declarator (identifier) (identifier))
+      (variable_declarator (identifier))
+      (variable_declarator (identifier))))
   (export_statement
-    (variable_name))
+    (identifier))
   (export_statement
     (function (formal_parameters) (statement_block)))
   (export_statement
-    (function (variable_name) (formal_parameters) (statement_block)))
+    (function (identifier) (formal_parameters) (statement_block)))
   (export_statement
-    (export_clause (export_specifier (variable_name) (variable_name))))
+    (export_clause (export_specifier (identifier) (identifier))))
   (export_statement
     (string))
   (export_statement
     (export_clause
-      (export_specifier (variable_name))
-      (export_specifier (variable_name))
-      (export_specifier (variable_name)))
+      (export_specifier (identifier))
+      (export_specifier (identifier))
+      (export_specifier (identifier)))
     (string))
   (export_statement
     (export_clause
-      (export_specifier (variable_name) (variable_name))
-      (export_specifier (variable_name) (variable_name))
-      (export_specifier (variable_name)))
+      (export_specifier (identifier) (identifier))
+      (export_specifier (identifier) (identifier))
+      (export_specifier (identifier)))
     (string)))
 
 ============================================
@@ -115,14 +115,14 @@ if (a.b) {
 ----
 
 (program
-  (if_statement (variable_name)
+  (if_statement (identifier)
     (expression_statement (function_call
-      (variable_name) (arguments (variable_name)))))
-  (if_statement (member_access (variable_name) (property_name))
+      (identifier) (arguments (identifier)))))
+  (if_statement (member_access (identifier) (property_identifier))
     (statement_block
       (expression_statement (function_call
-        (variable_name) (arguments (variable_name))))
-      (expression_statement (variable_name)))))
+        (identifier) (arguments (identifier))))
+      (expression_statement (identifier)))))
 
 ============================================
 If-else statements
@@ -143,16 +143,16 @@ if (a) {
 ----
 
 (program
-  (if_statement (variable_name)
-    (expression_statement (variable_name))
-    (if_statement (variable_name)
-      (expression_statement (variable_name))))
-  (if_statement (variable_name)
+  (if_statement (identifier)
+    (expression_statement (identifier))
+    (if_statement (identifier)
+      (expression_statement (identifier))))
+  (if_statement (identifier)
     (statement_block
-      (expression_statement (variable_name))
-      (expression_statement (variable_name)))
+      (expression_statement (identifier))
+      (expression_statement (identifier)))
     (statement_block
-      (expression_statement (variable_name)))))
+      (expression_statement (identifier)))))
 
 ============================================
 For statements
@@ -174,22 +174,22 @@ for (;;) {
 (program
   (for_statement
     (variable_declaration
-      (variable_declarator (variable_name))
-      (variable_declarator (variable_name)))
-    (variable_name)
-    (variable_name)
-    (expression_statement (variable_name)))
+      (variable_declarator (identifier))
+      (variable_declarator (identifier)))
+    (identifier)
+    (identifier)
+    (expression_statement (identifier)))
 
   (for_statement
-    (assignment (variable_name) (number))
-    (function_call (variable_name) (arguments))
-    (rel_op (variable_name) (number))
-    (math_op (variable_name))
-    (expression_statement (function_call (variable_name) (arguments (variable_name)))))
+    (assignment (identifier) (number))
+    (function_call (identifier) (arguments))
+    (rel_op (identifier) (number))
+    (math_op (identifier))
+    (expression_statement (function_call (identifier) (arguments (identifier)))))
 
   (for_statement
     (statement_block
-      (expression_statement (variable_name))
+      (expression_statement (identifier))
       (continue_statement))))
 
 ============================================
@@ -205,10 +205,10 @@ for (item in items)
 ---
 
 (program
-  (for_in_statement (variable_name) (variable_name)
-    (expression_statement (function_call (variable_name) (arguments))))
-  (for_in_statement (variable_name) (variable_name)
-    (expression_statement (function_call (variable_name) (arguments)))))
+  (for_in_statement (identifier) (identifier)
+    (expression_statement (function_call (identifier) (arguments))))
+  (for_in_statement (identifier) (identifier)
+    (expression_statement (function_call (identifier) (arguments)))))
 
 ==========================================
 For loops beginning with an in-expression
@@ -222,12 +222,12 @@ for (key in something && i = 0; i < n; i++) {
 
 (program (for_statement
   (bool_op
-    (type_op (variable_name) (variable_name))
-    (assignment (variable_name) (number)))
-  (rel_op (variable_name) (variable_name))
-  (math_op (variable_name))
+    (type_op (identifier) (identifier))
+    (assignment (identifier) (number)))
+  (rel_op (identifier) (identifier))
+  (math_op (identifier))
   (statement_block
-    (expression_statement (function_call (variable_name) (arguments))))))
+    (expression_statement (function_call (identifier) (arguments))))))
 
 ============================================
 For-of statements
@@ -239,8 +239,8 @@ for (let item of items)
 ---
 
 (program
-  (for_of_statement (variable_name) (variable_name)
-    (expression_statement (function_call (variable_name) (arguments (variable_name))))))
+  (for_of_statement (identifier) (identifier)
+    (expression_statement (function_call (identifier) (arguments (identifier))))))
 
 ============================================
 While statements
@@ -252,8 +252,8 @@ while (a)
 ---
 
 (program
-  (while_statement (variable_name)
-    (expression_statement (function_call (variable_name) (arguments)))))
+  (while_statement (identifier)
+    (expression_statement (function_call (identifier) (arguments)))))
 
 ============================================
 Do statements
@@ -267,8 +267,8 @@ do {
 
 (program
   (do_statement
-    (statement_block (expression_statement (variable_name)))
-    (variable_name)))
+    (statement_block (expression_statement (identifier)))
+    (identifier)))
 
 ============================================
 Return statements
@@ -286,8 +286,8 @@ return a;
   (return_statement)
   (return_statement (number))
   (return_statement (comma_op (number) (number)))
-  (return_statement (variable_name))
-  (return_statement (variable_name)))
+  (return_statement (identifier))
+  (return_statement (identifier)))
 
 ============================================
 Variable declarations
@@ -300,11 +300,11 @@ var x, y = {}, z;
 
 (program
   (variable_declaration
-    (variable_declarator (variable_name) (number)))
+    (variable_declarator (identifier) (number)))
   (variable_declaration
-    (variable_declarator (variable_name))
-    (variable_declarator (variable_name) (object))
-    (variable_declarator (variable_name))))
+    (variable_declarator (identifier))
+    (variable_declarator (identifier) (object))
+    (variable_declarator (identifier))))
 
 ============================================
 Comments
@@ -326,9 +326,9 @@ Comments
 (program
   (expression_statement (object
     (comment)
-    (pair (property_name) (number))
+    (pair (property_identifier) (number))
     (comment)
-    (pair (property_name) (function (formal_parameters) (statement_block))))))
+    (pair (property_identifier) (function (formal_parameters) (statement_block))))))
 
 ==========================================
 Comments between statements
@@ -354,19 +354,19 @@ var thing = {
   (comment)
   (comment)
   (variable_declaration (variable_declarator
-    (variable_name)
+    (identifier)
     (object
       (comment)
       (comment)
-      (pair (property_name) (function
-        (formal_parameters (variable_name) (comment))
+      (pair (property_identifier) (function
+        (formal_parameters (identifier) (comment))
         (statement_block
           (comment)
           (expression_statement
-            (function_call (variable_name) (arguments)))
+            (function_call (identifier) (arguments)))
           (comment)
           (expression_statement
-            (function_call (variable_name) (arguments))))))))))
+            (function_call (identifier) (arguments))))))))))
 
 ============================================
 Comments with asterisks
@@ -390,13 +390,13 @@ const d = 1;
 
 (program
   (comment)
-  (lexical_declaration (variable_declarator (variable_name) (number)))
+  (lexical_declaration (variable_declarator (identifier) (number)))
   (comment)
-  (lexical_declaration (variable_declarator (variable_name) (number)))
+  (lexical_declaration (variable_declarator (identifier) (number)))
   (comment)
-  (lexical_declaration (variable_declarator (variable_name) (number)))
+  (lexical_declaration (variable_declarator (identifier) (number)))
   (comment)
-  (lexical_declaration (variable_declarator (variable_name) (number))))
+  (lexical_declaration (variable_declarator (identifier) (number))))
 
 ==========================================
 Comments within expressions
@@ -408,7 +408,7 @@ y // comment
 ---
 
 (program (expression_statement
-  (math_op (variable_name) (comment) (variable_name))))
+  (math_op (identifier) (comment) (identifier))))
 
 ============================================
 Switch statements
@@ -429,13 +429,13 @@ switch (x) {
 ---
 
 (program
-  (switch_statement (variable_name)
+  (switch_statement (identifier)
     (case (number))
     (case (number)
-      (expression_statement (function_call (variable_name) (arguments)))
+      (expression_statement (function_call (identifier) (arguments)))
       (break_statement))
     (case (string)
-      (expression_statement (function_call (variable_name) (arguments)))
+      (expression_statement (function_call (identifier) (arguments)))
       (break_statement))
     (default
       (return_statement (number)))))
@@ -450,7 +450,7 @@ throw new Error("uh oh");
 
 (program
   (throw_statement
-    (new_expression (function_call (variable_name) (arguments (string))))))
+    (new_expression (function_call (identifier) (arguments (string))))))
 
 ============================================
 Throw statements with sequence expressions
@@ -462,9 +462,9 @@ throw g = 2, g
 
 (program
   (throw_statement
-    (comma_op (assignment (variable_name) (number)) (variable_name)))
+    (comma_op (assignment (identifier) (number)) (identifier)))
   (throw_statement
-    (comma_op (assignment (variable_name) (number)) (variable_name))))
+    (comma_op (assignment (identifier) (number)) (identifier))))
 
 ============================================
 Try catch finally statements
@@ -478,19 +478,19 @@ try { f; } catch { g; } finally { h; }
 
 (program
   (try_statement
-    (statement_block (expression_statement (variable_name)))
-    (catch (variable_name)
-      (statement_block (expression_statement (variable_name)))))
+    (statement_block (expression_statement (identifier)))
+    (catch (identifier)
+      (statement_block (expression_statement (identifier)))))
   (try_statement
-    (statement_block (expression_statement (variable_name)))
+    (statement_block (expression_statement (identifier)))
     (finally
-      (statement_block (expression_statement (variable_name)))))
+      (statement_block (expression_statement (identifier)))))
   (try_statement
-    (statement_block (expression_statement (variable_name)))
+    (statement_block (expression_statement (identifier)))
     (catch
-      (statement_block (expression_statement (variable_name))))
+      (statement_block (expression_statement (identifier))))
     (finally
-      (statement_block (expression_statement (variable_name))))))
+      (statement_block (expression_statement (identifier))))))
 
 ============================================
 Empty statements
@@ -523,11 +523,11 @@ for (;;) {
 ---
 
 (program
-  (labeled_statement (label_name)
+  (labeled_statement (statement_identifier)
     (for_statement (statement_block
-      (if_statement (variable_name)
-        (statement_block (break_statement (label_name)))
-        (statement_block (continue_statement (label_name))))))))
+      (if_statement (identifier)
+        (statement_block (break_statement (statement_identifier)))
+        (statement_block (continue_statement (statement_identifier))))))))
 
 ============================================
 Debugger statements
@@ -548,4 +548,4 @@ with (x) { i; }
 
 ---
 
-(program (with_statement (variable_name) (statement_block (expression_statement (variable_name)))))
+(program (with_statement (identifier) (statement_block (expression_statement (identifier)))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -16,23 +16,23 @@ import { member1 , member2 as alias2, } from "module-name";
 
 (program
   (import_statement
-    (import_clause (identifier)) (string))
+    (import_clause (variable_name)) (string))
   (import_statement
-    (import_clause (namespace_import (identifier))) (string))
+    (import_clause (namespace_import (variable_name))) (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (identifier)))) (string))
+    (import_clause (named_imports (import_specifier (variable_name)))) (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (identifier)) (import_specifier (identifier)))) (string))
+    (import_clause (named_imports (import_specifier (variable_name)) (import_specifier (variable_name)))) (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (identifier)) (import_specifier (identifier) (identifier)))) (string))
+    (import_clause (named_imports (import_specifier (variable_name)) (import_specifier (variable_name) (variable_name)))) (string))
   (import_statement
-    (import_clause (identifier) (named_imports (import_specifier (identifier)) (import_specifier (identifier) (identifier)))) (string))
+    (import_clause (variable_name) (named_imports (import_specifier (variable_name)) (import_specifier (variable_name) (variable_name)))) (string))
   (import_statement
-    (import_clause (identifier) (namespace_import (identifier))) (string))
+    (import_clause (variable_name) (namespace_import (variable_name))) (string))
   (import_statement
     (string))
   (import_statement
-    (import_clause (named_imports (import_specifier (identifier)) (import_specifier (identifier) (identifier)))) (string)))
+    (import_clause (named_imports (import_specifier (variable_name)) (import_specifier (variable_name) (variable_name)))) (string)))
 
 ============================================
 Exports
@@ -56,34 +56,49 @@ export { import1 as name1, import2 as name2, nameN } from 'foo';
 
 (program
   (export_statement
-    (export_clause (export_specifier (identifier)) (export_specifier (identifier)) (export_specifier (identifier)) (export_specifier (identifier))))
+    (export_clause
+      (export_specifier (variable_name))
+      (export_specifier (variable_name))
+      (export_specifier (variable_name))
+      (export_specifier (variable_name))))
   (export_statement
-    (export_clause (export_specifier (identifier) (identifier)) (export_specifier (identifier) (identifier)) (export_specifier (identifier))))
+    (export_clause
+      (export_specifier (variable_name) (variable_name))
+      (export_specifier (variable_name) (variable_name))
+      (export_specifier (variable_name))))
   (export_statement
     (lexical_declaration
-      (variable_declarator (identifier))
-      (variable_declarator (identifier))
-      (variable_declarator (identifier))))
+      (variable_declarator (variable_name))
+      (variable_declarator (variable_name))
+      (variable_declarator (variable_name))))
   (export_statement
     (lexical_declaration
-      (variable_declarator (identifier) (identifier))
-      (variable_declarator (identifier) (identifier))
-      (variable_declarator (identifier))
-      (variable_declarator (identifier))))
+      (variable_declarator (variable_name) (variable_name))
+      (variable_declarator (variable_name) (variable_name))
+      (variable_declarator (variable_name))
+      (variable_declarator (variable_name))))
   (export_statement
-    (identifier))
+    (variable_name))
   (export_statement
     (function (formal_parameters) (statement_block)))
   (export_statement
-    (function (identifier) (formal_parameters) (statement_block)))
+    (function (variable_name) (formal_parameters) (statement_block)))
   (export_statement
-    (export_clause (export_specifier (identifier) (identifier))))
+    (export_clause (export_specifier (variable_name) (variable_name))))
   (export_statement
     (string))
   (export_statement
-    (export_clause (export_specifier (identifier)) (export_specifier (identifier)) (export_specifier (identifier))) (string))
+    (export_clause
+      (export_specifier (variable_name))
+      (export_specifier (variable_name))
+      (export_specifier (variable_name)))
+    (string))
   (export_statement
-    (export_clause (export_specifier (identifier) (identifier)) (export_specifier (identifier) (identifier)) (export_specifier (identifier))) (string)))
+    (export_clause
+      (export_specifier (variable_name) (variable_name))
+      (export_specifier (variable_name) (variable_name))
+      (export_specifier (variable_name)))
+    (string)))
 
 ============================================
 If statements
@@ -100,14 +115,14 @@ if (a.b) {
 ----
 
 (program
-  (if_statement (identifier)
+  (if_statement (variable_name)
     (expression_statement (function_call
-      (identifier) (arguments (identifier)))))
-  (if_statement (member_access (identifier) (identifier))
+      (variable_name) (arguments (variable_name)))))
+  (if_statement (member_access (variable_name) (property_name))
     (statement_block
       (expression_statement (function_call
-        (identifier) (arguments (identifier))))
-      (expression_statement (identifier)))))
+        (variable_name) (arguments (variable_name))))
+      (expression_statement (variable_name)))))
 
 ============================================
 If-else statements
@@ -128,16 +143,16 @@ if (a) {
 ----
 
 (program
-  (if_statement (identifier)
-    (expression_statement (identifier))
-    (if_statement (identifier)
-      (expression_statement (identifier))))
-  (if_statement (identifier)
+  (if_statement (variable_name)
+    (expression_statement (variable_name))
+    (if_statement (variable_name)
+      (expression_statement (variable_name))))
+  (if_statement (variable_name)
     (statement_block
-      (expression_statement (identifier))
-      (expression_statement (identifier)))
+      (expression_statement (variable_name))
+      (expression_statement (variable_name)))
     (statement_block
-      (expression_statement (identifier)))))
+      (expression_statement (variable_name)))))
 
 ============================================
 For statements
@@ -159,22 +174,22 @@ for (;;) {
 (program
   (for_statement
     (variable_declaration
-      (variable_declarator (identifier))
-      (variable_declarator (identifier)))
-    (identifier)
-    (identifier)
-    (expression_statement (identifier)))
+      (variable_declarator (variable_name))
+      (variable_declarator (variable_name)))
+    (variable_name)
+    (variable_name)
+    (expression_statement (variable_name)))
 
   (for_statement
-    (assignment (identifier) (number))
-    (function_call (identifier) (arguments))
-    (rel_op (identifier) (number))
-    (math_op (identifier))
-    (expression_statement (function_call (identifier) (arguments (identifier)))))
+    (assignment (variable_name) (number))
+    (function_call (variable_name) (arguments))
+    (rel_op (variable_name) (number))
+    (math_op (variable_name))
+    (expression_statement (function_call (variable_name) (arguments (variable_name)))))
 
   (for_statement
     (statement_block
-      (expression_statement (identifier))
+      (expression_statement (variable_name))
       (continue_statement))))
 
 ============================================
@@ -190,10 +205,10 @@ for (item in items)
 ---
 
 (program
-  (for_in_statement (identifier) (identifier)
-    (expression_statement (function_call (identifier) (arguments))))
-  (for_in_statement (identifier) (identifier)
-    (expression_statement (function_call (identifier) (arguments)))))
+  (for_in_statement (variable_name) (variable_name)
+    (expression_statement (function_call (variable_name) (arguments))))
+  (for_in_statement (variable_name) (variable_name)
+    (expression_statement (function_call (variable_name) (arguments)))))
 
 ==========================================
 For loops beginning with an in-expression
@@ -207,12 +222,12 @@ for (key in something && i = 0; i < n; i++) {
 
 (program (for_statement
   (bool_op
-    (type_op (identifier) (identifier))
-    (assignment (identifier) (number)))
-  (rel_op (identifier) (identifier))
-  (math_op (identifier))
+    (type_op (variable_name) (variable_name))
+    (assignment (variable_name) (number)))
+  (rel_op (variable_name) (variable_name))
+  (math_op (variable_name))
   (statement_block
-    (expression_statement (function_call (identifier) (arguments))))))
+    (expression_statement (function_call (variable_name) (arguments))))))
 
 ============================================
 For-of statements
@@ -224,8 +239,8 @@ for (let item of items)
 ---
 
 (program
-  (for_of_statement (identifier) (identifier)
-    (expression_statement (function_call (identifier) (arguments (identifier))))))
+  (for_of_statement (variable_name) (variable_name)
+    (expression_statement (function_call (variable_name) (arguments (variable_name))))))
 
 ============================================
 While statements
@@ -237,8 +252,8 @@ while (a)
 ---
 
 (program
-  (while_statement (identifier)
-    (expression_statement (function_call (identifier) (arguments)))))
+  (while_statement (variable_name)
+    (expression_statement (function_call (variable_name) (arguments)))))
 
 ============================================
 Do statements
@@ -252,8 +267,8 @@ do {
 
 (program
   (do_statement
-    (statement_block (expression_statement (identifier)))
-    (identifier)))
+    (statement_block (expression_statement (variable_name)))
+    (variable_name)))
 
 ============================================
 Return statements
@@ -271,8 +286,8 @@ return a;
   (return_statement)
   (return_statement (number))
   (return_statement (comma_op (number) (number)))
-  (return_statement (reserved_identifier))
-  (return_statement (identifier)))
+  (return_statement (variable_name))
+  (return_statement (variable_name)))
 
 ============================================
 Variable declarations
@@ -285,11 +300,11 @@ var x, y = {}, z;
 
 (program
   (variable_declaration
-    (variable_declarator (identifier) (number)))
+    (variable_declarator (variable_name) (number)))
   (variable_declaration
-    (variable_declarator (identifier))
-    (variable_declarator (identifier) (object))
-    (variable_declarator (identifier))))
+    (variable_declarator (variable_name))
+    (variable_declarator (variable_name) (object))
+    (variable_declarator (variable_name))))
 
 ============================================
 Comments
@@ -311,9 +326,9 @@ Comments
 (program
   (expression_statement (object
     (comment)
-    (pair (identifier) (number))
+    (pair (property_name) (number))
     (comment)
-    (pair (identifier) (function (formal_parameters) (statement_block))))))
+    (pair (property_name) (function (formal_parameters) (statement_block))))))
 
 ==========================================
 Comments between statements
@@ -339,19 +354,19 @@ var thing = {
   (comment)
   (comment)
   (variable_declaration (variable_declarator
-    (identifier)
+    (variable_name)
     (object
       (comment)
       (comment)
-      (pair (identifier) (function
-        (formal_parameters (identifier) (comment))
+      (pair (property_name) (function
+        (formal_parameters (variable_name) (comment))
         (statement_block
           (comment)
           (expression_statement
-            (function_call (identifier) (arguments)))
+            (function_call (variable_name) (arguments)))
           (comment)
           (expression_statement
-            (function_call (identifier) (arguments))))))))))
+            (function_call (variable_name) (arguments))))))))))
 
 ============================================
 Comments with asterisks
@@ -375,13 +390,13 @@ const d = 1;
 
 (program
   (comment)
-  (lexical_declaration (variable_declarator (identifier) (number)))
+  (lexical_declaration (variable_declarator (variable_name) (number)))
   (comment)
-  (lexical_declaration (variable_declarator (identifier) (number)))
+  (lexical_declaration (variable_declarator (variable_name) (number)))
   (comment)
-  (lexical_declaration (variable_declarator (identifier) (number)))
+  (lexical_declaration (variable_declarator (variable_name) (number)))
   (comment)
-  (lexical_declaration (variable_declarator (identifier) (number))))
+  (lexical_declaration (variable_declarator (variable_name) (number))))
 
 ==========================================
 Comments within expressions
@@ -393,7 +408,7 @@ y // comment
 ---
 
 (program (expression_statement
-  (math_op (identifier) (comment) (identifier))))
+  (math_op (variable_name) (comment) (variable_name))))
 
 ============================================
 Switch statements
@@ -414,13 +429,13 @@ switch (x) {
 ---
 
 (program
-  (switch_statement (identifier)
+  (switch_statement (variable_name)
     (case (number))
     (case (number)
-      (expression_statement (function_call (identifier) (arguments)))
+      (expression_statement (function_call (variable_name) (arguments)))
       (break_statement))
     (case (string)
-      (expression_statement (function_call (identifier) (arguments)))
+      (expression_statement (function_call (variable_name) (arguments)))
       (break_statement))
     (default
       (return_statement (number)))))
@@ -435,7 +450,7 @@ throw new Error("uh oh");
 
 (program
   (throw_statement
-    (new_expression (function_call (identifier) (arguments (string))))))
+    (new_expression (function_call (variable_name) (arguments (string))))))
 
 ============================================
 Throw statements with sequence expressions
@@ -447,9 +462,9 @@ throw g = 2, g
 
 (program
   (throw_statement
-    (comma_op (assignment (identifier) (number)) (identifier)))
+    (comma_op (assignment (variable_name) (number)) (variable_name)))
   (throw_statement
-    (comma_op (assignment (identifier) (number)) (identifier))))
+    (comma_op (assignment (variable_name) (number)) (variable_name))))
 
 ============================================
 Try catch finally statements
@@ -463,19 +478,19 @@ try { f; } catch { g; } finally { h; }
 
 (program
   (try_statement
-    (statement_block (expression_statement (identifier)))
-    (catch (identifier)
-      (statement_block (expression_statement (identifier)))))
+    (statement_block (expression_statement (variable_name)))
+    (catch (variable_name)
+      (statement_block (expression_statement (variable_name)))))
   (try_statement
-    (statement_block (expression_statement (identifier)))
+    (statement_block (expression_statement (variable_name)))
     (finally
-      (statement_block (expression_statement (identifier)))))
+      (statement_block (expression_statement (variable_name)))))
   (try_statement
-    (statement_block (expression_statement (identifier)))
+    (statement_block (expression_statement (variable_name)))
     (catch
-      (statement_block (expression_statement (identifier))))
+      (statement_block (expression_statement (variable_name))))
     (finally
-      (statement_block (expression_statement (identifier))))))
+      (statement_block (expression_statement (variable_name))))))
 
 ============================================
 Empty statements
@@ -508,11 +523,11 @@ for (;;) {
 ---
 
 (program
-  (labeled_statement (identifier)
+  (labeled_statement (label_name)
     (for_statement (statement_block
-      (if_statement (identifier)
-        (statement_block (break_statement (identifier)))
-        (statement_block (continue_statement (identifier))))))))
+      (if_statement (variable_name)
+        (statement_block (break_statement (label_name)))
+        (statement_block (continue_statement (label_name))))))))
 
 ============================================
 Debugger statements
@@ -533,27 +548,4 @@ with (x) { i; }
 
 ---
 
-(program (with_statement (identifier) (statement_block (expression_statement (identifier)))))
-
-============================================
-Abstract as identifier
-============================================
-
-abstract
-
----
-
-(program (expression_statement (reserved_identifier)))
-
-
-============================================
-Interface as identifier
-============================================
-
-interface
-
----
-
-(program (expression_statement (reserved_identifier)))
-
-
+(program (with_statement (variable_name) (statement_block (expression_statement (variable_name)))))

--- a/grammar.js
+++ b/grammar.js
@@ -67,15 +67,15 @@ module.exports = grammar({
 
     export_clause: $ => seq(
       '{',
-      commaSep(rename($._import_export_specifier, 'export_specifier')),
+      commaSep(alias($._import_export_specifier, $.export_specifier)),
       '}'
     ),
 
     _import_export_specifier: $ => seq(
-      rename($.identifier, 'variable_name'),
+      alias($.identifier, $.variable_name),
       optional(seq(
         'as',
-        rename($.identifier, 'variable_name')
+        alias($.identifier, $.variable_name)
       ))
     ),
 
@@ -109,7 +109,7 @@ module.exports = grammar({
       $.namespace_import,
       $.named_imports,
       seq(
-        rename($.identifier, 'variable_name'),
+        alias($.identifier, $.variable_name),
         optional(seq(
           ',',
           choice(
@@ -125,12 +125,12 @@ module.exports = grammar({
     ),
 
     namespace_import: $ => seq(
-      "*", "as", rename($.identifier, 'variable_name')
+      "*", "as", alias($.identifier, $.variable_name)
     ),
 
     named_imports: $ => seq(
       '{',
-      commaSep(rename($._import_export_specifier, 'import_specifier')),
+      commaSep(alias($._import_export_specifier, $.import_specifier)),
       optional(','),
       '}'
     ),
@@ -184,7 +184,7 @@ module.exports = grammar({
 
     variable_declarator: $ => choice(
       seq(
-        rename($.identifier, 'variable_name'),
+        alias($.identifier, $.variable_name),
         optional($._initializer)
       ),
       seq(
@@ -289,13 +289,13 @@ module.exports = grammar({
 
     break_statement: $ => seq(
       'break',
-      optional(rename($.identifier, 'label_name')),
+      optional(alias($.identifier, $.label_name)),
       $._semicolon
     ),
 
     continue_statement: $ => seq(
       'continue',
-      optional(rename($.identifier, 'label_name')),
+      optional(alias($.identifier, $.label_name)),
       $._semicolon
     ),
 
@@ -319,7 +319,7 @@ module.exports = grammar({
     empty_statement: $ => ';',
 
     labeled_statement: $ => seq(
-      rename($.identifier, 'label_name'),
+      alias($.identifier, $.label_name),
       ':',
       $._statement
     ),
@@ -343,7 +343,7 @@ module.exports = grammar({
 
     catch: $ => seq(
       'catch',
-      optional(seq('(', rename($.identifier, 'variable_name'), ')')),
+      optional(seq('(', alias($.identifier, $.variable_name), ')')),
       $.statement_block
     ),
 
@@ -396,12 +396,12 @@ module.exports = grammar({
       $.null,
       $.undefined,
       $.yield_expression,
-      rename(choice(
+      alias(choice(
         $.identifier,
         'get',
         'set',
         'async'
-      ), 'variable_name')
+      ), $.variable_name)
     ),
 
     yield_expression: $ => prec.right(seq(
@@ -418,18 +418,18 @@ module.exports = grammar({
     _property_definition_list: $ => commaSep1Trailing($._property_definition_list, choice(
       $.pair,
       $.method_definition,
-      rename(choice(
+      alias(choice(
         $.identifier,
         'get',
         'set',
         'async'
-      ), 'shorthand_property_name'),
+      ), $.shorthand_property_name),
       $.spread_element,
       $.assignment_pattern
     )),
 
     assignment_pattern: $ => seq(
-      rename($.identifier, 'shorthand_property_name'),
+      alias($.identifier, $.shorthand_property_name),
       $._initializer
     ),
 
@@ -503,7 +503,7 @@ module.exports = grammar({
 
     class: $ => seq(
       'class',
-      rename($.identifier, 'variable_name'),
+      alias($.identifier, $.variable_name),
       $._class_tail
     ),
 
@@ -517,7 +517,7 @@ module.exports = grammar({
     function: $ => seq(
       optional('async'),
       'function',
-      optional(rename($.identifier, 'variable_name')),
+      optional(alias($.identifier, $.variable_name)),
       $.formal_parameters,
       $.statement_block
     ),
@@ -525,7 +525,7 @@ module.exports = grammar({
     arrow_function: $ => seq(
       optional('async'),
       choice(
-        optional(rename($.identifier, 'variable_name')),
+        optional(alias($.identifier, $.variable_name)),
         $.formal_parameters
       ),
       '=>',
@@ -538,7 +538,7 @@ module.exports = grammar({
     generator_function: $ => seq(
       'function',
       '*',
-      optional(rename($.identifier, 'variable_name')),
+      optional(alias($.identifier, $.variable_name)),
       $.formal_parameters,
       $.statement_block
     ),
@@ -561,7 +561,7 @@ module.exports = grammar({
     member_access: $ => prec(PREC.MEMBER, seq(
       $._expression,
       '.',
-      rename($.identifier, 'property_name')
+      alias($.identifier, $.property_name)
     )),
 
     subscript_access: $ => prec.right(PREC.MEMBER, seq(
@@ -573,7 +573,7 @@ module.exports = grammar({
       choice(
         $.member_access,
         $.subscript_access,
-        rename($.identifier, 'variable_name'),
+        alias($.identifier, $.variable_name),
         $._destructuring_pattern
       ),
       $._initializer
@@ -585,7 +585,7 @@ module.exports = grammar({
 
     math_assignment: $ => prec.right(PREC.ASSIGN, seq(
       choice(
-        rename($.identifier, 'variable_name'),
+        alias($.identifier, $.variable_name),
         $.member_access,
         $.subscript_access
       ),
@@ -594,8 +594,8 @@ module.exports = grammar({
     )),
 
     _destructuring_pattern: $ => choice(
-      rename($.object, 'object_pattern'),
-      rename($.array, 'array_pattern')
+      alias($.object, $.object_pattern),
+      alias($.array, $.array_pattern)
     ),
 
     spread_element: $ => seq('...', $._expression),
@@ -789,7 +789,7 @@ module.exports = grammar({
     formal_parameters: $ => seq(
       '(',
       commaSep(choice(
-        rename($.identifier, 'variable_name'),
+        alias($.identifier, $.variable_name),
         $._destructuring_pattern
       )),
       ')'
@@ -818,12 +818,12 @@ module.exports = grammar({
     ),
 
     _property_name: $ => choice(
-      rename(choice(
+      alias(choice(
         $.identifier,
         'get',
         'set',
         'async'
-      ), 'property_name'),
+      ), $.property_name),
       $.string,
       $.number
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -34,7 +34,8 @@ module.exports = grammar({
 
   inline: $ => [
     $._statement,
-    $._semicolon
+    $._semicolon,
+    $._destructuring_pattern,
   ],
 
   conflicts: $ => [
@@ -42,7 +43,6 @@ module.exports = grammar({
     [$.labeled_statement, $._property_name],
     [$.reserved_identifier, $.arrow_function],
     [$.formal_parameters, $._expression],
-    [$.destructuring_pattern, $._expression],
     [$._expression, $._property_definition_list],
     [$.assignment_pattern, $.assignment],
     [$.method_definition, $.reserved_identifier]
@@ -174,7 +174,7 @@ module.exports = grammar({
 
     variable_declarator: $ => choice(
       seq($.identifier, optional($._initializer)),
-      seq($.destructuring_pattern, $._initializer)
+      seq($._destructuring_pattern, $._initializer)
     ),
 
     statement_block: $ => seq(
@@ -551,7 +551,7 @@ module.exports = grammar({
         $.member_access,
         $.subscript_access,
         $.identifier,
-        $.destructuring_pattern
+        $._destructuring_pattern
       ),
       $._initializer
     )),
@@ -570,9 +570,9 @@ module.exports = grammar({
       $._expression
     )),
 
-    destructuring_pattern: $ => choice(
-      $.object,
-      $.array
+    _destructuring_pattern: $ => choice(
+      rename($.object, 'object_pattern'),
+      rename($.array, 'array_pattern')
     ),
 
     spread_element: $ => seq('...', $._expression),
@@ -762,7 +762,7 @@ module.exports = grammar({
 
     formal_parameters: $ => seq(
       '(',
-      commaSep(choice($.identifier, $.destructuring_pattern)),
+      commaSep(choice($.identifier, $._destructuring_pattern)),
       ')'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -72,10 +72,10 @@ module.exports = grammar({
     ),
 
     _import_export_specifier: $ => seq(
-      alias($.identifier, $.variable_name),
+      $.identifier,
       optional(seq(
         'as',
-        alias($.identifier, $.variable_name)
+        $.identifier
       ))
     ),
 
@@ -109,7 +109,7 @@ module.exports = grammar({
       $.namespace_import,
       $.named_imports,
       seq(
-        alias($.identifier, $.variable_name),
+        $.identifier,
         optional(seq(
           ',',
           choice(
@@ -125,7 +125,7 @@ module.exports = grammar({
     ),
 
     namespace_import: $ => seq(
-      "*", "as", alias($.identifier, $.variable_name)
+      "*", "as", $.identifier
     ),
 
     named_imports: $ => seq(
@@ -184,7 +184,7 @@ module.exports = grammar({
 
     variable_declarator: $ => choice(
       seq(
-        alias($.identifier, $.variable_name),
+        $.identifier,
         optional($._initializer)
       ),
       seq(
@@ -289,13 +289,13 @@ module.exports = grammar({
 
     break_statement: $ => seq(
       'break',
-      optional(alias($.identifier, $.label_name)),
+      optional(alias($.identifier, $.statement_identifier)),
       $._semicolon
     ),
 
     continue_statement: $ => seq(
       'continue',
-      optional(alias($.identifier, $.label_name)),
+      optional(alias($.identifier, $.statement_identifier)),
       $._semicolon
     ),
 
@@ -319,7 +319,7 @@ module.exports = grammar({
     empty_statement: $ => ';',
 
     labeled_statement: $ => seq(
-      alias($.identifier, $.label_name),
+      alias($.identifier, $.statement_identifier),
       ':',
       $._statement
     ),
@@ -343,7 +343,7 @@ module.exports = grammar({
 
     catch: $ => seq(
       'catch',
-      optional(seq('(', alias($.identifier, $.variable_name), ')')),
+      optional(seq('(', $.identifier, ')')),
       $.statement_block
     ),
 
@@ -396,12 +396,12 @@ module.exports = grammar({
       $.null,
       $.undefined,
       $.yield_expression,
+      $.identifier,
       alias(choice(
-        $.identifier,
         'get',
         'set',
         'async'
-      ), $.variable_name)
+      ), $.identifier)
     ),
 
     yield_expression: $ => prec.right(seq(
@@ -423,13 +423,13 @@ module.exports = grammar({
         'get',
         'set',
         'async'
-      ), $.shorthand_property_name),
+      ), $.shorthand_property_identifier),
       $.spread_element,
       $.assignment_pattern
     )),
 
     assignment_pattern: $ => seq(
-      alias($.identifier, $.shorthand_property_name),
+      alias($.identifier, $.shorthand_property_identifier),
       $._initializer
     ),
 
@@ -479,7 +479,7 @@ module.exports = grammar({
     ),
 
     jsx_attribute: $ => seq(
-      $.identifier,
+      alias($.identifier, $.property_identifier),
       optional(seq(
         '=',
         choice(
@@ -503,7 +503,7 @@ module.exports = grammar({
 
     class: $ => seq(
       'class',
-      alias($.identifier, $.variable_name),
+      $.identifier,
       $._class_tail
     ),
 
@@ -517,7 +517,7 @@ module.exports = grammar({
     function: $ => seq(
       optional('async'),
       'function',
-      optional(alias($.identifier, $.variable_name)),
+      optional($.identifier),
       $.formal_parameters,
       $.statement_block
     ),
@@ -525,7 +525,7 @@ module.exports = grammar({
     arrow_function: $ => seq(
       optional('async'),
       choice(
-        optional(alias($.identifier, $.variable_name)),
+        optional($.identifier),
         $.formal_parameters
       ),
       '=>',
@@ -538,7 +538,7 @@ module.exports = grammar({
     generator_function: $ => seq(
       'function',
       '*',
-      optional(alias($.identifier, $.variable_name)),
+      optional($.identifier),
       $.formal_parameters,
       $.statement_block
     ),
@@ -561,7 +561,7 @@ module.exports = grammar({
     member_access: $ => prec(PREC.MEMBER, seq(
       $._expression,
       '.',
-      alias($.identifier, $.property_name)
+      alias($.identifier, $.property_identifier)
     )),
 
     subscript_access: $ => prec.right(PREC.MEMBER, seq(
@@ -573,7 +573,7 @@ module.exports = grammar({
       choice(
         $.member_access,
         $.subscript_access,
-        alias($.identifier, $.variable_name),
+        $.identifier,
         $._destructuring_pattern
       ),
       $._initializer
@@ -585,7 +585,7 @@ module.exports = grammar({
 
     math_assignment: $ => prec.right(PREC.ASSIGN, seq(
       choice(
-        alias($.identifier, $.variable_name),
+        $.identifier,
         $.member_access,
         $.subscript_access
       ),
@@ -789,7 +789,7 @@ module.exports = grammar({
     formal_parameters: $ => seq(
       '(',
       commaSep(choice(
-        alias($.identifier, $.variable_name),
+        $.identifier,
         $._destructuring_pattern
       )),
       ')'
@@ -823,7 +823,7 @@ module.exports = grammar({
         'get',
         'set',
         'async'
-      ), $.property_name),
+      ), $.property_identifier),
       $.string,
       $.number
     ),

--- a/index.js
+++ b/index.js
@@ -1,1 +1,9 @@
-module.exports = require("./build/Release/tree_sitter_javascript_binding");
+try {
+  module.exports = require("./build/Release/tree_sitter_javascript_binding");
+} catch (error) {
+  try {
+    module.exports = require("./build/Debug/tree_sitter_javascript_binding");
+  } catch (_) {
+    throw error
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "acorn": "^2.6.4",
     "babylon": "^6.3.26",
     "esprima": "^2.7.1",
-    "tree-sitter-cli": "^0.6.3"
+    "tree-sitter-cli": "^0.6.6-0"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "acorn": "^2.6.4",
     "babylon": "^6.3.26",
     "esprima": "^2.7.1",
-    "tree-sitter-cli": "^0.5.3"
+    "tree-sitter-cli": "^0.6.3"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -137,8 +137,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "export_specifier"
+                  "type": "RENAME",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_import_export_specifier"
+                  },
+                  "value": "export_specifier"
                 },
                 {
                   "type": "REPEAT",
@@ -150,8 +154,12 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "export_specifier"
+                        "type": "RENAME",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_import_export_specifier"
+                        },
+                        "value": "export_specifier"
                       }
                     ]
                   }
@@ -169,27 +177,39 @@
         }
       ]
     },
-    "export_specifier": {
-      "type": "CHOICE",
+    "_import_export_specifier": {
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "RENAME",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "value": "variable_name"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "as"
+                },
+                {
+                  "type": "RENAME",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  "value": "variable_name"
+                }
+              ]
             },
             {
-              "type": "STRING",
-              "value": "as"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "BLANK"
             }
           ]
         }
@@ -296,39 +316,44 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "RENAME",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "value": "variable_name"
             },
             {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "SYMBOL",
-              "name": "namespace_import"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "namespace_import"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "named_imports"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "SYMBOL",
-              "name": "named_imports"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
         }
       ]
     },
@@ -357,8 +382,12 @@
           "value": "as"
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "RENAME",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "value": "variable_name"
         }
       ]
     },
@@ -376,8 +405,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "import_specifier"
+                  "type": "RENAME",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_import_export_specifier"
+                  },
+                  "value": "import_specifier"
                 },
                 {
                   "type": "REPEAT",
@@ -389,8 +422,12 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "import_specifier"
+                        "type": "RENAME",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_import_export_specifier"
+                        },
+                        "value": "import_specifier"
                       }
                     ]
                   }
@@ -417,32 +454,6 @@
         {
           "type": "STRING",
           "value": "}"
-        }
-      ]
-    },
-    "import_specifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "STRING",
-              "value": "as"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            }
-          ]
         }
       ]
     },
@@ -649,8 +660,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "RENAME",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "value": "variable_name"
             },
             {
               "type": "CHOICE",
@@ -1112,7 +1127,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_expression"
                 },
                 {
                   "type": "STRING",
@@ -1146,8 +1161,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "RENAME",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "value": "label_name"
             },
             {
               "type": "BLANK"
@@ -1171,8 +1190,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "RENAME",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "value": "label_name"
             },
             {
               "type": "BLANK"
@@ -1266,8 +1289,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "RENAME",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "value": "label_name"
         },
         {
           "type": "STRING",
@@ -1341,8 +1368,12 @@
                   "value": "("
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "identifier"
+                  "type": "RENAME",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  "value": "variable_name"
                 },
                 {
                   "type": "STRING",
@@ -1505,10 +1536,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
           "name": "number"
         },
         {
@@ -1544,8 +1571,29 @@
           "name": "yield_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "reserved_identifier"
+          "type": "RENAME",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "STRING",
+                "value": "get"
+              },
+              {
+                "type": "STRING",
+                "value": "set"
+              },
+              {
+                "type": "STRING",
+                "value": "async"
+              }
+            ]
+          },
+          "value": "variable_name"
         }
       ]
     },
@@ -1618,12 +1666,29 @@
               "name": "method_definition"
             },
             {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "reserved_identifier"
+              "type": "RENAME",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "get"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "set"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "async"
+                  }
+                ]
+              },
+              "value": "shorthand_property_name"
             },
             {
               "type": "SYMBOL",
@@ -1670,8 +1735,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "RENAME",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "value": "shorthand_property_name"
         },
         {
           "type": "SYMBOL",
@@ -1981,8 +2050,12 @@
           "value": "class"
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "RENAME",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "value": "variable_name"
         },
         {
           "type": "SYMBOL",
@@ -2047,8 +2120,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "RENAME",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "value": "variable_name"
             },
             {
               "type": "BLANK"
@@ -2084,8 +2161,20 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "RENAME",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  "value": "variable_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "SYMBOL",
@@ -2127,8 +2216,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "RENAME",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              "value": "variable_name"
             },
             {
               "type": "BLANK"
@@ -2229,8 +2322,12 @@
             "value": "."
           },
           {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "RENAME",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            "value": "property_name"
           }
         ]
       }
@@ -2278,8 +2375,12 @@
                 "name": "subscript_access"
               },
               {
-                "type": "SYMBOL",
-                "name": "identifier"
+                "type": "RENAME",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                "value": "variable_name"
               },
               {
                 "type": "SYMBOL",
@@ -2317,8 +2418,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "identifier"
+                "type": "RENAME",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                "value": "variable_name"
               },
               {
                 "type": "SYMBOL",
@@ -3352,7 +3457,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "template_chars"
+                "name": "_template_chars"
               },
               {
                 "type": "SYMBOL",
@@ -3367,17 +3472,26 @@
         }
       ]
     },
-    "template_chars": {
+    "_template_chars": {
       "type": "TOKEN",
       "content": {
-        "type": "PREC_RIGHT",
-        "value": 0,
+        "type": "REPEAT1",
         "content": {
-          "type": "REPEAT1",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^`\\$]|\\$[^{]|\\\\`"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[^`\\$]"
+            },
+            {
+              "type": "PATTERN",
+              "value": "\\$[^{]"
+            },
+            {
+              "type": "PATTERN",
+              "value": "\\\\`"
+            }
+          ]
         }
       }
     },
@@ -4037,8 +4151,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "identifier"
+                      "type": "RENAME",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      "value": "variable_name"
                     },
                     {
                       "type": "SYMBOL",
@@ -4059,8 +4177,12 @@
                         "type": "CHOICE",
                         "members": [
                           {
-                            "type": "SYMBOL",
-                            "name": "identifier"
+                            "type": "RENAME",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "identifier"
+                            },
+                            "value": "variable_name"
                           },
                           {
                             "type": "SYMBOL",
@@ -4214,12 +4336,29 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "reserved_identifier"
+          "type": "RENAME",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "STRING",
+                "value": "get"
+              },
+              {
+                "type": "STRING",
+                "value": "set"
+              },
+              {
+                "type": "STRING",
+                "value": "async"
+              }
+            ]
+          },
+          "value": "property_name"
         },
         {
           "type": "SYMBOL",
@@ -4228,31 +4367,6 @@
         {
           "type": "SYMBOL",
           "name": "number"
-        }
-      ]
-    },
-    "reserved_identifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "get"
-        },
-        {
-          "type": "STRING",
-          "value": "set"
-        },
-        {
-          "type": "STRING",
-          "value": "async"
-        },
-        {
-          "type": "STRING",
-          "value": "abstract"
-        },
-        {
-          "type": "STRING",
-          "value": "interface"
         }
       ]
     },
@@ -4286,28 +4400,33 @@
       "_property_name"
     ],
     [
-      "labeled_statement",
-      "_property_name"
-    ],
-    [
-      "reserved_identifier",
+      "_expression",
+      "_property_name",
       "arrow_function"
     ],
     [
-      "formal_parameters",
-      "_expression"
+      "_expression",
+      "arrow_function"
+    ],
+    [
+      "_expression",
+      "method_definition"
+    ],
+    [
+      "_expression",
+      "formal_parameters"
     ],
     [
       "_expression",
       "_property_definition_list"
     ],
     [
-      "assignment_pattern",
-      "assignment"
+      "labeled_statement",
+      "_property_name"
     ],
     [
-      "method_definition",
-      "reserved_identifier"
+      "assignment_pattern",
+      "assignment"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -137,11 +137,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "RENAME",
+                  "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
                     "name": "_import_export_specifier"
                   },
+                  "named": true,
                   "value": "export_specifier"
                 },
                 {
@@ -154,11 +155,12 @@
                         "value": ","
                       },
                       {
-                        "type": "RENAME",
+                        "type": "ALIAS",
                         "content": {
                           "type": "SYMBOL",
                           "name": "_import_export_specifier"
                         },
+                        "named": true,
                         "value": "export_specifier"
                       }
                     ]
@@ -181,11 +183,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "identifier"
           },
+          "named": true,
           "value": "variable_name"
         },
         {
@@ -199,11 +202,12 @@
                   "value": "as"
                 },
                 {
-                  "type": "RENAME",
+                  "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
                     "name": "identifier"
                   },
+                  "named": true,
                   "value": "variable_name"
                 }
               ]
@@ -316,11 +320,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "RENAME",
+              "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
                 "name": "identifier"
               },
+              "named": true,
               "value": "variable_name"
             },
             {
@@ -382,11 +387,12 @@
           "value": "as"
         },
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "identifier"
           },
+          "named": true,
           "value": "variable_name"
         }
       ]
@@ -405,11 +411,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "RENAME",
+                  "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
                     "name": "_import_export_specifier"
                   },
+                  "named": true,
                   "value": "import_specifier"
                 },
                 {
@@ -422,11 +429,12 @@
                         "value": ","
                       },
                       {
-                        "type": "RENAME",
+                        "type": "ALIAS",
                         "content": {
                           "type": "SYMBOL",
                           "name": "_import_export_specifier"
                         },
+                        "named": true,
                         "value": "import_specifier"
                       }
                     ]
@@ -660,11 +668,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "RENAME",
+              "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
                 "name": "identifier"
               },
+              "named": true,
               "value": "variable_name"
             },
             {
@@ -1161,11 +1170,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "RENAME",
+              "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
                 "name": "identifier"
               },
+              "named": true,
               "value": "label_name"
             },
             {
@@ -1190,11 +1200,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "RENAME",
+              "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
                 "name": "identifier"
               },
+              "named": true,
               "value": "label_name"
             },
             {
@@ -1289,11 +1300,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "identifier"
           },
+          "named": true,
           "value": "label_name"
         },
         {
@@ -1368,11 +1380,12 @@
                   "value": "("
                 },
                 {
-                  "type": "RENAME",
+                  "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
                     "name": "identifier"
                   },
+                  "named": true,
                   "value": "variable_name"
                 },
                 {
@@ -1571,7 +1584,7 @@
           "name": "yield_expression"
         },
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "CHOICE",
             "members": [
@@ -1593,6 +1606,7 @@
               }
             ]
           },
+          "named": true,
           "value": "variable_name"
         }
       ]
@@ -1666,7 +1680,7 @@
               "name": "method_definition"
             },
             {
-              "type": "RENAME",
+              "type": "ALIAS",
               "content": {
                 "type": "CHOICE",
                 "members": [
@@ -1688,6 +1702,7 @@
                   }
                 ]
               },
+              "named": true,
               "value": "shorthand_property_name"
             },
             {
@@ -1735,11 +1750,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "identifier"
           },
+          "named": true,
           "value": "shorthand_property_name"
         },
         {
@@ -2050,11 +2066,12 @@
           "value": "class"
         },
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "identifier"
           },
+          "named": true,
           "value": "variable_name"
         },
         {
@@ -2120,11 +2137,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "RENAME",
+              "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
                 "name": "identifier"
               },
+              "named": true,
               "value": "variable_name"
             },
             {
@@ -2164,11 +2182,12 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "RENAME",
+                  "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
                     "name": "identifier"
                   },
+                  "named": true,
                   "value": "variable_name"
                 },
                 {
@@ -2216,11 +2235,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "RENAME",
+              "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
                 "name": "identifier"
               },
+              "named": true,
               "value": "variable_name"
             },
             {
@@ -2322,11 +2342,12 @@
             "value": "."
           },
           {
-            "type": "RENAME",
+            "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
               "name": "identifier"
             },
+            "named": true,
             "value": "property_name"
           }
         ]
@@ -2375,11 +2396,12 @@
                 "name": "subscript_access"
               },
               {
-                "type": "RENAME",
+                "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
                   "name": "identifier"
                 },
+                "named": true,
                 "value": "variable_name"
               },
               {
@@ -2418,11 +2440,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "RENAME",
+                "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
                   "name": "identifier"
                 },
+                "named": true,
                 "value": "variable_name"
               },
               {
@@ -2483,19 +2506,21 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "object"
           },
+          "named": true,
           "value": "object_pattern"
         },
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "array"
           },
+          "named": true,
           "value": "array_pattern"
         }
       ]
@@ -4151,11 +4176,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "RENAME",
+                      "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
                         "name": "identifier"
                       },
+                      "named": true,
                       "value": "variable_name"
                     },
                     {
@@ -4177,11 +4203,12 @@
                         "type": "CHOICE",
                         "members": [
                           {
-                            "type": "RENAME",
+                            "type": "ALIAS",
                             "content": {
                               "type": "SYMBOL",
                               "name": "identifier"
                             },
+                            "named": true,
                             "value": "variable_name"
                           },
                           {
@@ -4336,7 +4363,7 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "RENAME",
+          "type": "ALIAS",
           "content": {
             "type": "CHOICE",
             "members": [
@@ -4358,6 +4385,7 @@
               }
             ]
           },
+          "named": true,
           "value": "property_name"
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -671,7 +671,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "destructuring_pattern"
+              "name": "_destructuring_pattern"
             },
             {
               "type": "SYMBOL",
@@ -2283,7 +2283,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "destructuring_pattern"
+                "name": "_destructuring_pattern"
               }
             ]
           },
@@ -2374,16 +2374,24 @@
         ]
       }
     },
-    "destructuring_pattern": {
+    "_destructuring_pattern": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "object"
+          "type": "RENAME",
+          "content": {
+            "type": "SYMBOL",
+            "name": "object"
+          },
+          "value": "object_pattern"
         },
         {
-          "type": "SYMBOL",
-          "name": "array"
+          "type": "RENAME",
+          "content": {
+            "type": "SYMBOL",
+            "name": "array"
+          },
+          "value": "array_pattern"
         }
       ]
     },
@@ -4034,7 +4042,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "destructuring_pattern"
+                      "name": "_destructuring_pattern"
                     }
                   ]
                 },
@@ -4056,7 +4064,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "destructuring_pattern"
+                            "name": "_destructuring_pattern"
                           }
                         ]
                       }
@@ -4290,10 +4298,6 @@
       "_expression"
     ],
     [
-      "destructuring_pattern",
-      "_expression"
-    ],
-    [
       "_expression",
       "_property_definition_list"
     ],
@@ -4314,6 +4318,7 @@
   ],
   "inline": [
     "_statement",
-    "_semicolon"
+    "_semicolon",
+    "_destructuring_pattern"
   ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -27,17 +27,8 @@
               "name": "_from_clause"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -57,17 +48,8 @@
               "name": "_from_clause"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -83,17 +65,8 @@
               "name": "export_clause"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         },
@@ -143,17 +116,8 @@
               "name": "_expression"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_automatic_semicolon"
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_semicolon"
             }
           ]
         }
@@ -312,17 +276,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -597,17 +552,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -644,17 +590,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -700,17 +637,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1123,17 +1051,8 @@
           "name": "_paren_expression"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1211,17 +1130,8 @@
           "name": "statement_block"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1245,17 +1155,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1279,17 +1180,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1301,17 +1193,8 @@
           "value": "debugger"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1344,17 +1227,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1379,17 +1253,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_automatic_semicolon"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -1685,25 +1550,29 @@
       ]
     },
     "yield_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "yield"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "yield"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "object": {
       "type": "PREC",
@@ -2409,17 +2278,12 @@
                 "name": "subscript_access"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "destructuring_pattern"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "destructuring_pattern"
               }
             ]
           },
@@ -4111,17 +3975,8 @@
                         "name": "public_field_definition"
                       },
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "_automatic_semicolon"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": ";"
-                          }
-                        ]
+                        "type": "SYMBOL",
+                        "name": "_semicolon"
                       }
                     ]
                   }
@@ -4392,6 +4247,19 @@
           "value": "interface"
         }
       ]
+    },
+    "_semicolon": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_automatic_semicolon"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
     }
   },
   "extras": [
@@ -4434,9 +4302,6 @@
       "assignment"
     ],
     [
-      "yield_expression"
-    ],
-    [
       "method_definition",
       "reserved_identifier"
     ]
@@ -4446,5 +4311,9 @@
       "type": "SYMBOL",
       "name": "_automatic_semicolon"
     }
+  ],
+  "inline": [
+    "_statement",
+    "_semicolon"
   ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -183,13 +183,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
-          },
-          "named": true,
-          "value": "variable_name"
+          "type": "SYMBOL",
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -202,13 +197,8 @@
                   "value": "as"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  "named": true,
-                  "value": "variable_name"
+                  "type": "SYMBOL",
+                  "name": "identifier"
                 }
               ]
             },
@@ -320,13 +310,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              "named": true,
-              "value": "variable_name"
+              "type": "SYMBOL",
+              "name": "identifier"
             },
             {
               "type": "CHOICE",
@@ -387,13 +372,8 @@
           "value": "as"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
-          },
-          "named": true,
-          "value": "variable_name"
+          "type": "SYMBOL",
+          "name": "identifier"
         }
       ]
     },
@@ -668,13 +648,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              "named": true,
-              "value": "variable_name"
+              "type": "SYMBOL",
+              "name": "identifier"
             },
             {
               "type": "CHOICE",
@@ -1176,7 +1151,7 @@
                 "name": "identifier"
               },
               "named": true,
-              "value": "label_name"
+              "value": "statement_identifier"
             },
             {
               "type": "BLANK"
@@ -1206,7 +1181,7 @@
                 "name": "identifier"
               },
               "named": true,
-              "value": "label_name"
+              "value": "statement_identifier"
             },
             {
               "type": "BLANK"
@@ -1306,7 +1281,7 @@
             "name": "identifier"
           },
           "named": true,
-          "value": "label_name"
+          "value": "statement_identifier"
         },
         {
           "type": "STRING",
@@ -1380,13 +1355,8 @@
                   "value": "("
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  "named": true,
-                  "value": "variable_name"
+                  "type": "SYMBOL",
+                  "name": "identifier"
                 },
                 {
                   "type": "STRING",
@@ -1584,14 +1554,14 @@
           "name": "yield_expression"
         },
         {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
           "type": "ALIAS",
           "content": {
             "type": "CHOICE",
             "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
               {
                 "type": "STRING",
                 "value": "get"
@@ -1607,7 +1577,7 @@
             ]
           },
           "named": true,
-          "value": "variable_name"
+          "value": "identifier"
         }
       ]
     },
@@ -1703,7 +1673,7 @@
                 ]
               },
               "named": true,
-              "value": "shorthand_property_name"
+              "value": "shorthand_property_identifier"
             },
             {
               "type": "SYMBOL",
@@ -1756,7 +1726,7 @@
             "name": "identifier"
           },
           "named": true,
-          "value": "shorthand_property_name"
+          "value": "shorthand_property_identifier"
         },
         {
           "type": "SYMBOL",
@@ -1937,8 +1907,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          "named": true,
+          "value": "property_identifier"
         },
         {
           "type": "CHOICE",
@@ -2066,13 +2041,8 @@
           "value": "class"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
-          },
-          "named": true,
-          "value": "variable_name"
+          "type": "SYMBOL",
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -2137,13 +2107,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              "named": true,
-              "value": "variable_name"
+              "type": "SYMBOL",
+              "name": "identifier"
             },
             {
               "type": "BLANK"
@@ -2182,13 +2147,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  "named": true,
-                  "value": "variable_name"
+                  "type": "SYMBOL",
+                  "name": "identifier"
                 },
                 {
                   "type": "BLANK"
@@ -2235,13 +2195,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              "named": true,
-              "value": "variable_name"
+              "type": "SYMBOL",
+              "name": "identifier"
             },
             {
               "type": "BLANK"
@@ -2348,7 +2303,7 @@
               "name": "identifier"
             },
             "named": true,
-            "value": "property_name"
+            "value": "property_identifier"
           }
         ]
       }
@@ -2396,13 +2351,8 @@
                 "name": "subscript_access"
               },
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                "named": true,
-                "value": "variable_name"
+                "type": "SYMBOL",
+                "name": "identifier"
               },
               {
                 "type": "SYMBOL",
@@ -2440,13 +2390,8 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                "named": true,
-                "value": "variable_name"
+                "type": "SYMBOL",
+                "name": "identifier"
               },
               {
                 "type": "SYMBOL",
@@ -4176,13 +4121,8 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      "named": true,
-                      "value": "variable_name"
+                      "type": "SYMBOL",
+                      "name": "identifier"
                     },
                     {
                       "type": "SYMBOL",
@@ -4203,13 +4143,8 @@
                         "type": "CHOICE",
                         "members": [
                           {
-                            "type": "ALIAS",
-                            "content": {
-                              "type": "SYMBOL",
-                              "name": "identifier"
-                            },
-                            "named": true,
-                            "value": "variable_name"
+                            "type": "SYMBOL",
+                            "name": "identifier"
                           },
                           {
                             "type": "SYMBOL",
@@ -4386,7 +4321,7 @@
             ]
           },
           "named": true,
-          "value": "property_name"
+          "value": "property_identifier"
         },
         {
           "type": "SYMBOL",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -6,10 +6,10 @@ enum TokenType {
 };
 
 void *tree_sitter_javascript_external_scanner_create() { return NULL; }
-void tree_sitter_javascript_external_scanner_destroy(void *payload) {}
-void tree_sitter_javascript_external_scanner_reset(void *payload) {}
-bool tree_sitter_javascript_external_scanner_serialize(void *payload, TSExternalTokenState state) { return true; }
-void tree_sitter_javascript_external_scanner_deserialize(void *payload, TSExternalTokenState state) {}
+void tree_sitter_javascript_external_scanner_destroy(void *p) {}
+void tree_sitter_javascript_external_scanner_reset(void *p) {}
+unsigned tree_sitter_javascript_external_scanner_serialize(void *p, char *buffer) { return 0; }
+void tree_sitter_javascript_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
 
 static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -42,6 +42,7 @@ typedef struct {
   union {
     TSStateId to_state;
     struct {
+      short dynamic_precedence;
       TSSymbol symbol;
       unsigned short child_count;
     };
@@ -145,21 +146,30 @@ typedef struct TSLanguage {
     { .type = TSParseActionTypeShift, .extra = true } \
   }
 
-#define REDUCE(symbol_val, child_count_val)                             \
+#define REDUCE(symbol_val, child_count_val, dynamic_precedence_val)     \
   {                                                                     \
     {                                                                   \
       .type = TSParseActionTypeReduce,                                  \
-      .params = {.symbol = symbol_val, .child_count = child_count_val } \
+      .params = {                                                       \
+        .symbol = symbol_val,                                           \
+        .child_count = child_count_val,                                 \
+        .dynamic_precedence = dynamic_precedence_val,                   \
+      }                                                                 \
     }                                                                   \
   }
 
-#define REDUCE_FRAGILE(symbol_val, child_count_val)                     \
-  {                                                                     \
-    {                                                                   \
-      .type = TSParseActionTypeReduce, .fragile = true,                 \
-      .params = {.symbol = symbol_val, .child_count = child_count_val } \
-    }                                                                   \
-  }
+#define REDUCE_FRAGILE(symbol_val, child_count_val, dynamic_precedence_val) \
+{                                                                           \
+  {                                                                         \
+    .type = TSParseActionTypeReduce,                                        \
+    .fragile = true,                                                        \
+    .params = {                                                             \
+      .symbol = symbol_val,                                                 \
+      .child_count = child_count_val,                                       \
+      .dynamic_precedence = dynamic_precedence_val,                         \
+    }                                                                       \
+  }                                                                         \
+}
 
 #define ACCEPT_INPUT()                  \
   {                                     \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -40,17 +40,17 @@ typedef enum {
 typedef struct {
   union {
     struct {
-      TSStateId to_state;
+      TSStateId state;
       bool extra : 1;
     };
     struct {
       TSSymbol symbol;
       int16_t dynamic_precedence;
       uint8_t child_count;
-      uint8_t rename_sequence_id : 7;
+      uint8_t alias_sequence_id : 7;
       bool fragile : 1;
     };
-  };
+  } params;
   TSParseActionType type : 4;
 } TSParseAction;
 
@@ -71,7 +71,7 @@ typedef union {
 typedef struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
-  uint32_t rename_symbol_count;
+  uint32_t alias_count;
   uint32_t token_count;
   uint32_t external_token_count;
   const char **symbol_names;
@@ -79,8 +79,8 @@ typedef struct TSLanguage {
   const uint16_t *parse_table;
   const TSParseActionEntry *parse_actions;
   const TSLexMode *lex_modes;
-  const TSSymbol *rename_sequences;
-  uint16_t max_rename_sequence_length;
+  const TSSymbol *alias_sequences;
+  uint16_t max_alias_sequence_length;
   bool (*lex_fn)(TSLexer *, TSStateId);
   struct {
     const bool *states;
@@ -131,19 +131,19 @@ typedef struct TSLanguage {
 #define STATE(id) id
 #define ACTIONS(id) id
 
-#define SHIFT(to_state_value)         \
-  {                                   \
-    {                                 \
-      .type = TSParseActionTypeShift, \
-      .to_state = to_state_value,     \
-    }                                 \
+#define SHIFT(state_value)              \
+  {                                     \
+    {                                   \
+      .type = TSParseActionTypeShift,   \
+      .params = {.state = state_value}, \
+    }                                   \
   }
 
-#define RECOVER(to_state_value)         \
+#define RECOVER(state_value)            \
   {                                     \
     {                                   \
       .type = TSParseActionTypeRecover, \
-      .to_state = to_state_value        \
+      .params = {.state = state_value}  \
     }                                   \
   }
 
@@ -151,7 +151,7 @@ typedef struct TSLanguage {
   {                                   \
     {                                 \
       .type = TSParseActionTypeShift, \
-      .extra = true                   \
+      .params = {.extra = true}       \
     }                                 \
   }
 
@@ -159,9 +159,11 @@ typedef struct TSLanguage {
   {                                              \
     {                                            \
       .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
+      .params = {                                \
+        .symbol = symbol_val,                    \
+        .child_count = child_count_val,          \
+        __VA_ARGS__                              \
+      }                                          \
     }                                            \
   }
 
@@ -170,24 +172,24 @@ typedef struct TSLanguage {
     { .type = TSParseActionTypeAccept } \
   }
 
-#define GET_LANGUAGE(...)                                      \
-  static TSLanguage language = {                               \
-    .version = LANGUAGE_VERSION,                               \
-    .symbol_count = SYMBOL_COUNT,                              \
-    .rename_symbol_count = RENAME_SYMBOL_COUNT,                \
-    .token_count = TOKEN_COUNT,                                \
-    .symbol_metadata = ts_symbol_metadata,                     \
-    .parse_table = (const unsigned short *)ts_parse_table,     \
-    .parse_actions = ts_parse_actions,                         \
-    .lex_modes = ts_lex_modes,                                 \
-    .symbol_names = ts_symbol_names,                           \
-    .rename_sequences = (const TSSymbol *)ts_rename_sequences, \
-    .max_rename_sequence_length = MAX_RENAME_SEQUENCE_LENGTH,  \
-    .lex_fn = ts_lex,                                          \
-    .external_token_count = EXTERNAL_TOKEN_COUNT,              \
-    .external_scanner = {__VA_ARGS__}                          \
-  };                                                           \
-  return &language                                             \
+#define GET_LANGUAGE(...)                                    \
+  static TSLanguage language = {                             \
+    .version = LANGUAGE_VERSION,                             \
+    .symbol_count = SYMBOL_COUNT,                            \
+    .alias_count = ALIAS_COUNT,                              \
+    .token_count = TOKEN_COUNT,                              \
+    .symbol_metadata = ts_symbol_metadata,                   \
+    .parse_table = (const unsigned short *)ts_parse_table,   \
+    .parse_actions = ts_parse_actions,                       \
+    .lex_modes = ts_lex_modes,                               \
+    .symbol_names = ts_symbol_names,                         \
+    .alias_sequences = (const TSSymbol *)ts_alias_sequences, \
+    .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,  \
+    .lex_fn = ts_lex,                                        \
+    .external_token_count = EXTERNAL_TOKEN_COUNT,            \
+    .external_scanner = {__VA_ARGS__}                        \
+  };                                                         \
+  return &language                                           \
 
 #ifdef __cplusplus
 }

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -9,13 +9,12 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef unsigned short TSSymbol;
-typedef unsigned short TSStateId;
-
-typedef uint8_t TSExternalTokenState[16];
+typedef uint16_t TSSymbol;
+typedef uint16_t TSStateId;
 
 #define ts_builtin_sym_error ((TSSymbol)-1)
 #define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
 typedef struct {
   bool visible : 1;
@@ -40,16 +39,19 @@ typedef enum {
 
 typedef struct {
   union {
-    TSStateId to_state;
     struct {
-      short dynamic_precedence;
-      TSSymbol symbol;
-      unsigned short child_count;
+      TSStateId to_state;
+      bool extra : 1;
     };
-  } params;
+    struct {
+      TSSymbol symbol;
+      int16_t dynamic_precedence;
+      uint8_t child_count;
+      uint8_t rename_sequence_id : 7;
+      bool fragile : 1;
+    };
+  };
   TSParseActionType type : 4;
-  bool extra : 1;
-  bool fragile : 1;
 } TSParseAction;
 
 typedef struct {
@@ -60,7 +62,7 @@ typedef struct {
 typedef union {
   TSParseAction action;
   struct {
-    unsigned short count;
+    uint8_t count;
     bool reusable : 1;
     bool depends_on_lookahead : 1;
   };
@@ -69,23 +71,25 @@ typedef union {
 typedef struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
+  uint32_t rename_symbol_count;
   uint32_t token_count;
   uint32_t external_token_count;
   const char **symbol_names;
   const TSSymbolMetadata *symbol_metadata;
-  const unsigned short *parse_table;
+  const uint16_t *parse_table;
   const TSParseActionEntry *parse_actions;
   const TSLexMode *lex_modes;
+  const TSSymbol *rename_sequences;
+  uint16_t max_rename_sequence_length;
   bool (*lex_fn)(TSLexer *, TSStateId);
   struct {
     const bool *states;
     const TSSymbol *symbol_map;
     void *(*create)();
     void (*destroy)(void *);
-    void (*reset)(void *);
     bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
-    bool (*serialize)(void *, TSExternalTokenState);
-    void (*deserialize)(void *, const TSExternalTokenState);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
 } TSLanguage;
 
@@ -127,70 +131,63 @@ typedef struct TSLanguage {
 #define STATE(id) id
 #define ACTIONS(id) id
 
-#define SHIFT(to_state_value)                                                 \
-  {                                                                           \
-    {                                                                         \
-      .type = TSParseActionTypeShift, .params = {.to_state = to_state_value } \
-    }                                                                         \
+#define SHIFT(to_state_value)         \
+  {                                   \
+    {                                 \
+      .type = TSParseActionTypeShift, \
+      .to_state = to_state_value,     \
+    }                                 \
   }
 
-#define RECOVER(to_state_value)                                                 \
-  {                                                                             \
-    {                                                                           \
-      .type = TSParseActionTypeRecover, .params = {.to_state = to_state_value } \
-    }                                                                           \
+#define RECOVER(to_state_value)         \
+  {                                     \
+    {                                   \
+      .type = TSParseActionTypeRecover, \
+      .to_state = to_state_value        \
+    }                                   \
   }
 
-#define SHIFT_EXTRA()                                 \
-  {                                                   \
-    { .type = TSParseActionTypeShift, .extra = true } \
+#define SHIFT_EXTRA()                 \
+  {                                   \
+    {                                 \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
   }
 
-#define REDUCE(symbol_val, child_count_val, dynamic_precedence_val)     \
-  {                                                                     \
-    {                                                                   \
-      .type = TSParseActionTypeReduce,                                  \
-      .params = {                                                       \
-        .symbol = symbol_val,                                           \
-        .child_count = child_count_val,                                 \
-        .dynamic_precedence = dynamic_precedence_val,                   \
-      }                                                                 \
-    }                                                                   \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {                                              \
+    {                                            \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    }                                            \
   }
-
-#define REDUCE_FRAGILE(symbol_val, child_count_val, dynamic_precedence_val) \
-{                                                                           \
-  {                                                                         \
-    .type = TSParseActionTypeReduce,                                        \
-    .fragile = true,                                                        \
-    .params = {                                                             \
-      .symbol = symbol_val,                                                 \
-      .child_count = child_count_val,                                       \
-      .dynamic_precedence = dynamic_precedence_val,                         \
-    }                                                                       \
-  }                                                                         \
-}
 
 #define ACCEPT_INPUT()                  \
   {                                     \
     { .type = TSParseActionTypeAccept } \
   }
 
-#define GET_LANGUAGE(...)                                          \
-  static TSLanguage language = {                                   \
-    .version = LANGUAGE_VERSION,                                   \
-    .symbol_count = SYMBOL_COUNT,                                  \
-    .token_count = TOKEN_COUNT,                                    \
-    .symbol_metadata = ts_symbol_metadata,                         \
-    .parse_table = (const unsigned short *)ts_parse_table,         \
-    .parse_actions = ts_parse_actions,                             \
-    .lex_modes = ts_lex_modes,                                     \
-    .symbol_names = ts_symbol_names,                               \
-    .lex_fn = ts_lex,                                              \
-    .external_token_count = EXTERNAL_TOKEN_COUNT,                  \
-    .external_scanner = {__VA_ARGS__}                              \
-  };                                                               \
-  return &language                                                 \
+#define GET_LANGUAGE(...)                                      \
+  static TSLanguage language = {                               \
+    .version = LANGUAGE_VERSION,                               \
+    .symbol_count = SYMBOL_COUNT,                              \
+    .rename_symbol_count = RENAME_SYMBOL_COUNT,                \
+    .token_count = TOKEN_COUNT,                                \
+    .symbol_metadata = ts_symbol_metadata,                     \
+    .parse_table = (const unsigned short *)ts_parse_table,     \
+    .parse_actions = ts_parse_actions,                         \
+    .lex_modes = ts_lex_modes,                                 \
+    .symbol_names = ts_symbol_names,                           \
+    .rename_sequences = (const TSSymbol *)ts_rename_sequences, \
+    .max_rename_sequence_length = MAX_RENAME_SEQUENCE_LENGTH,  \
+    .lex_fn = ts_lex,                                          \
+    .external_token_count = EXTERNAL_TOKEN_COUNT,              \
+    .external_scanner = {__VA_ARGS__}                          \
+  };                                                           \
+  return &language                                             \
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR updates the grammar to take advantage of tree-sitter's new [contextual renames feature](https://github.com/tree-sitter/tree-sitter/pull/90).

Some nodes that used to be simply called `identifier` will now be called `property_identifier`, `shorthand_property_identifier`, or `label_identifier`. Also, that pesky `reserved_identifier` rule is gone; when a keyword like `get` or `async` needs to be interpreted as a `property_identifier` or an `identifier`, it will appear exactly like any other node of that type.

Another improvement is that array and object destructuring patterns are now called `array_pattern` and `object_pattern` respectively, instead of appearing as an `array` or `object` wrapped in a `destructuring_pattern` node.

These changes will make the AST much easier to analyze in order to e.g. highlight all usages of a local variable in Atom.
