### PR TITLE
Use more consistent naming convention for expression rules

### DIFF
--- a/corpus/destructuring.txt
+++ b/corpus/destructuring.txt
@@ -50,7 +50,8 @@ Array destructuring assignments
 ============================================
 
 [a, b] = array;
-[a, b, ...c] = array
+[a, b, ...c] = array;
+[,, c,, d,] = array;
 
 ---
 
@@ -65,6 +66,11 @@ Array destructuring assignments
       (identifier)
       (identifier)
       (spread_element (identifier)))
+    (identifier)))
+  (expression_statement (assignment_expression
+    (array_pattern
+      (identifier)
+      (identifier))
     (identifier))))
 
 ================================================

--- a/corpus/destructuring.txt
+++ b/corpus/destructuring.txt
@@ -9,7 +9,7 @@ const {a, b: {c, d}} = object
 ---
 
 (program
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (object_pattern
       (shorthand_property_identifier)
       (shorthand_property_identifier))
@@ -55,12 +55,12 @@ Array destructuring assignments
 ---
 
 (program
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (array_pattern
       (identifier)
       (identifier))
     (identifier)))
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (array_pattern
       (identifier)
       (identifier)
@@ -79,5 +79,5 @@ function a({b = true}, [c, d = false]) {}
   (function (identifier)
     (formal_parameters
       (object_pattern (assignment_pattern (shorthand_property_identifier) (true)))
-      (array_pattern (identifier) (assignment (identifier) (false))))
+      (array_pattern (identifier) (assignment_expression (identifier) (false))))
     (statement_block)))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -936,7 +936,7 @@ foo(...rest)
 
 (program
   (expression_statement
-    (call_expression (identifier) (arguments (rest_argument (identifier))))))
+    (call_expression (identifier) (arguments (spread_element (identifier))))))
 
 ==============================================
 Forward slashes after parenthesized expressions

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -42,19 +42,18 @@ Template strings
   (expression_statement (template_string))
   (expression_statement (template_string))
   (expression_statement (template_string
-    (template_substitution (math_op
-      (number)
-      (number)))
-    (template_substitution (comma_op
-      (math_op (number) (number))
-      (math_op (number) (number))))))
+    (template_substitution
+      (binary_expression (number) (number)))
+    (template_substitution (sequence_expression
+      (binary_expression (number) (number))
+      (binary_expression (number) (number))))))
   (expression_statement (template_string))
   (expression_statement (template_string
     (template_substitution (number))))
 	(expression_statement (template_string))
   (expression_statement (template_string
-    (template_substitution (function_call
-      (member_access (identifier) (property_identifier))
+    (template_substitution (call_expression
+      (member_expression (identifier) (property_identifier))
       (arguments (string))))
     (template_substitution (identifier)))))
 
@@ -67,7 +66,7 @@ f `hello`;
 ---
 
 (program
-  (expression_statement (function_call (identifier) (template_string))))
+  (expression_statement (call_expression (identifier) (template_string))))
 
 ============================================
 Numbers
@@ -197,10 +196,10 @@ y = {a,};
 ---
 
 (program
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (identifier)
     (object (shorthand_property_identifier) (shorthand_property_identifier) (shorthand_property_identifier))))
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (identifier)
     (object (shorthand_property_identifier)))))
 
@@ -233,7 +232,7 @@ Objects with method definitions
       (property_identifier)
       (formal_parameters (identifier) (identifier))
       (statement_block
-        (return_statement (math_op (identifier) (identifier)))))
+        (return_statement (binary_expression (identifier) (identifier)))))
     (method_definition
       (property_identifier)
       (formal_parameters)
@@ -243,7 +242,7 @@ Objects with method definitions
       (property_identifier)
       (formal_parameters (identifier))
       (statement_block
-        (expression_statement (assignment (identifier) (identifier)))))
+        (expression_statement (assignment_expression (identifier) (identifier)))))
     (method_definition
       (property_identifier)
       (formal_parameters)
@@ -319,13 +318,13 @@ class Foo extends require('another-class') {
 
   (class
     (identifier)
-    (class_heritage (function_call (identifier) (arguments (string))))
+    (class_heritage (call_expression (identifier) (arguments (string))))
     (class_body
       (method_definition
         (property_identifier)
         (formal_parameters)
         (statement_block
-          (expression_statement (function_call (super) (arguments))))))))
+          (expression_statement (call_expression (super) (arguments))))))))
 
 ============================================
 Class Property Fields
@@ -362,7 +361,7 @@ Arrays
   (expression_statement (array (string)))
   (expression_statement (array (string) (identifier)))
   (expression_statement (array (identifier)))
-  (expression_statement (array (assignment (identifier) (number)))))
+  (expression_statement (array (assignment_expression (identifier) (number)))))
 
 ============================================
 Functions
@@ -457,9 +456,9 @@ x["some-string"];
 ---
 
 (program
-  (expression_statement (member_access (identifier) (property_identifier)))
-  (expression_statement (subscript_access (identifier) (identifier)))
-  (expression_statement (subscript_access (identifier) (string))))
+  (expression_statement (member_expression (identifier) (property_identifier)))
+  (expression_statement (subscript_expression (identifier) (identifier)))
+  (expression_statement (subscript_expression (identifier) (string))))
 
 ============================================
 Chained Property access
@@ -472,17 +471,17 @@ return returned.promise()
 ---
 
 (program (return_statement
-  (function_call
-    (member_access
-      (function_call
-        (member_access
-          (function_call
-            (member_access (identifier) (property_identifier))
+  (call_expression
+    (member_expression
+      (call_expression
+        (member_expression
+          (call_expression
+            (member_expression (identifier) (property_identifier))
             (arguments))
           (property_identifier))
-        (arguments (member_access (identifier) (property_identifier))))
+        (arguments (member_expression (identifier) (property_identifier))))
       (property_identifier))
-  (arguments (member_access (identifier) (property_identifier))))))
+  (arguments (member_expression (identifier) (property_identifier))))))
 
 ============================================
 Chained callbacks
@@ -502,17 +501,17 @@ return this.map(function (a) {
 
 
 (program (return_statement
-  (function_call
-    (member_access
-      (function_call
-        (member_access (this_expression) (property_identifier))
+  (call_expression
+    (member_expression
+      (call_expression
+        (member_expression (this_expression) (property_identifier))
         (arguments
           (function (formal_parameters (identifier)) (statement_block
-            (return_statement (member_access (identifier) (property_identifier)))))))
+            (return_statement (member_expression (identifier) (property_identifier)))))))
         (comment)
       (property_identifier))
       (arguments (function (formal_parameters (identifier)) (statement_block
-        (return_statement (member_access (identifier) (property_identifier)))))))))
+        (return_statement (member_expression (identifier) (property_identifier)))))))))
 
 ============================================
 Function calls
@@ -526,10 +525,10 @@ function(x, y) {
 ---
 
 (program
-  (expression_statement (function_call
-    (member_access (identifier) (property_identifier))
+  (expression_statement (call_expression
+    (member_expression (identifier) (property_identifier))
     (arguments (identifier) (string))))
-  (expression_statement (function_call
+  (expression_statement (call_expression
     (function
       (formal_parameters (identifier) (identifier))
       (statement_block))
@@ -545,8 +544,8 @@ new Thing;
 ---
 
 (program
-  (expression_statement (new_expression (function_call
-    (member_access (identifier) (property_identifier))
+  (expression_statement (new_expression (call_expression
+    (member_expression (identifier) (property_identifier))
     (arguments (number) (string)))))
   (expression_statement (new_expression
     (identifier))))
@@ -563,7 +562,7 @@ await asyncPromise;
 (program
   (expression_statement
     (await_expression
-      (function_call (identifier) (arguments))))
+      (call_expression (identifier) (arguments))))
   (expression_statement (await_expression (identifier))))
 
 ============================================
@@ -620,15 +619,15 @@ i + j * 3 - j % 5;
 ---
 
 (program
-  (expression_statement (math_op (identifier)))
-  (expression_statement (math_op (identifier)))
-  (expression_statement (math_op
-    (math_op
+  (expression_statement (update_expression (identifier)))
+  (expression_statement (update_expression (identifier)))
+  (expression_statement (binary_expression
+    (binary_expression
       (identifier)
-      (math_op (identifier) (number)))
-    (math_op (identifier) (number))))
-  (expression_statement (math_op (identifier)))
-  (expression_statement (math_op (identifier))))
+      (binary_expression (identifier) (number)))
+    (binary_expression (identifier) (number))))
+  (expression_statement (unary_expression (identifier)))
+  (expression_statement (unary_expression (identifier))))
 
 ============================================
 Boolean operators
@@ -641,15 +640,15 @@ i && j;
 ---
 
 (program
-  (expression_statement (bool_op (identifier) (identifier)))
-  (expression_statement (bool_op (identifier) (identifier)))
-  (expression_statement (bool_op
-    (bool_op
-      (bool_op (identifier))
-      (bool_op (identifier)))
-    (bool_op
-      (bool_op (identifier))
-      (bool_op (identifier))))))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression
+    (binary_expression
+      (unary_expression (identifier))
+      (unary_expression (identifier)))
+    (binary_expression
+      (unary_expression (identifier))
+      (unary_expression (identifier))))))
 
 ============================================
 Bitwise operators
@@ -668,17 +667,17 @@ i | j;
 ---
 
 (program
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (bitwise_op
-    (bitwise_op (identifier))
-    (bitwise_op (identifier)))))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression
+    (unary_expression (identifier))
+    (unary_expression (identifier)))))
 
 ============================================
 Relational operators
@@ -696,14 +695,14 @@ x > y;
 ---
 
 (program
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier))))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier))))
 
 ==============================================
 Assignments
@@ -716,14 +715,14 @@ x["y"] = 0;
 ---
 
 (program
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (identifier)
     (number)))
-  (expression_statement (assignment
-    (member_access (identifier) (property_identifier))
+  (expression_statement (assignment_expression
+    (member_expression (identifier) (property_identifier))
     (number)))
-  (expression_statement (assignment
-    (subscript_access (identifier) (string))
+  (expression_statement (assignment_expression
+    (subscript_expression (identifier) (string))
     (number))))
 
 ==============================================
@@ -736,14 +735,18 @@ c = {d: (3, 4 + 5, 6)};
 ---
 
 (program
-  (expression_statement (comma_op
-    (assignment (identifier) (number))
-    (assignment (identifier) (number))))
+  (expression_statement (sequence_expression
+    (assignment_expression (identifier) (number))
+    (assignment_expression (identifier) (number))))
   (expression_statement
-    (assignment (identifier) (object
+    (assignment_expression (identifier) (object
       (pair
         (property_identifier)
-        (comma_op (number) (comma_op (math_op (number) (number)) (number))))))))
+        (parenthesized_expression (sequence_expression
+          (number)
+          (sequence_expression
+            (binary_expression (number) (number))
+            (number)))))))))
 
 ==============================================
 Ternaries
@@ -757,14 +760,14 @@ x.y = some.condition ?
 ---
 
 (program
-  (expression_statement (ternary
+  (expression_statement (ternary_expression
     (identifier) (identifier) (identifier)))
-  (expression_statement (assignment
-    (member_access (identifier) (property_identifier))
-    (ternary
-      (member_access (identifier) (property_identifier))
-      (member_access (identifier) (property_identifier))
-      (member_access (member_access (identifier) (property_identifier)) (property_identifier))))))
+  (expression_statement (assignment_expression
+    (member_expression (identifier) (property_identifier))
+    (ternary_expression
+      (member_expression (identifier) (property_identifier))
+      (member_expression (identifier) (property_identifier))
+      (member_expression (member_expression (identifier) (property_identifier)) (property_identifier))))))
 
 ==============================================
 Type operators
@@ -776,8 +779,8 @@ x instanceof String;
 ---
 
 (program
-  (expression_statement (type_op (identifier)))
-  (expression_statement (type_op (identifier) (identifier))))
+  (expression_statement (unary_expression (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier))))
 
 ============================================
 The delete operator
@@ -790,10 +793,10 @@ true ? delete thing.prop : null;
 
 (program
   (expression_statement
-    (delete_op (subscript_access (identifier) (string))))
+    (unary_expression (subscript_expression (identifier) (string))))
   (expression_statement
-    (ternary (true)
-      (delete_op (member_access (identifier) (property_identifier)))
+    (ternary_expression (true)
+      (unary_expression (member_expression (identifier) (property_identifier)))
       (null))))
 
 ============================================
@@ -804,12 +807,12 @@ a = void b()
 
 ---
 
-(program (expression_statement (assignment
+(program (expression_statement (assignment_expression
   (identifier)
-  (void_op (function_call (identifier) (arguments))))))
+  (unary_expression (call_expression (identifier) (arguments))))))
 
 ==============================================
-Math assignment operators
+Math assignment_expression operators
 ==============================================
 
 s |= 1;
@@ -822,15 +825,15 @@ y.z *= 5;
 
 (program
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (augmented_assignment_expression (identifier) (number)))
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (augmented_assignment_expression (identifier) (number)))
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (augmented_assignment_expression (identifier) (number)))
   (expression_statement
-    (math_assignment (identifier) (number)))
+    (augmented_assignment_expression (identifier) (number)))
   (expression_statement
-    (math_assignment (member_access (identifier) (property_identifier)) (number))))
+    (augmented_assignment_expression (member_expression (identifier) (property_identifier)) (number))))
 
 ==============================================
 Operator precedence
@@ -845,27 +848,27 @@ typeof a == b && c instanceof d
 ---
 
 (program
-  (expression_statement (bool_op
-    (rel_op (identifier) (identifier))
-    (rel_op (identifier) (identifier))))
-  (expression_statement (assignment
-    (member_access (identifier) (property_identifier))
-    (ternary (identifier) (identifier) (identifier))))
-  (expression_statement (bool_op
-    (bool_op
+  (expression_statement (binary_expression
+    (binary_expression (identifier) (identifier))
+    (binary_expression (identifier) (identifier))))
+  (expression_statement (assignment_expression
+    (member_expression (identifier) (property_identifier))
+    (ternary_expression (identifier) (identifier) (identifier))))
+  (expression_statement (binary_expression
+    (binary_expression
       (identifier)
-      (function_call (identifier) (arguments (identifier))))
+      (call_expression (identifier) (arguments (identifier))))
     (identifier)))
-  (expression_statement (bool_op
-    (bool_op
+  (expression_statement (binary_expression
+    (binary_expression
       (identifier)
-      (new_expression (function_call (identifier) (arguments (identifier)))))
+      (new_expression (call_expression (identifier) (arguments (identifier)))))
     (identifier)))
-  (expression_statement (bool_op
-    (rel_op
-      (type_op (identifier))
+  (expression_statement (binary_expression
+    (binary_expression
+      (unary_expression (identifier))
       (identifier))
-    (type_op (identifier) (identifier)))))
+    (binary_expression (identifier) (identifier)))))
 
 ==============================================
 Simple JSX elements
@@ -877,13 +880,13 @@ b = <div>a <span>b</span> c</div>;
 ---
 
 (program
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (identifier)
     (jsx_self_closing_element
       (identifier)
       (jsx_attribute (property_identifier) (string))
       (jsx_attribute (property_identifier) (number)))))
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (identifier)
     (jsx_element
       (jsx_opening_element (identifier))
@@ -905,7 +908,7 @@ h = <i>{...j}</i>
 ---
 
 (program
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (identifier)
     (jsx_element
       (jsx_opening_element (identifier)
@@ -915,7 +918,7 @@ h = <i>{...j}</i>
       (jsx_expression (identifier))
       (jsx_text)
       (jsx_closing_element (identifier)))))
-  (expression_statement (assignment
+  (expression_statement (assignment_expression
     (identifier)
     (jsx_element
       (jsx_opening_element (identifier))
@@ -933,19 +936,25 @@ foo(...rest)
 
 (program
   (expression_statement
-    (function_call (identifier) (arguments (rest_argument (identifier))))))
+    (call_expression (identifier) (arguments (rest_argument (identifier))))))
 
 ==============================================
-Math expressions
+Forward slashes after parenthesized expressions
 ==============================================
 
 (foo - bar) / baz
+if (foo - bar) /baz/
 
 ---
 
 (program
   (expression_statement
-    (math_op (math_op (identifier) (identifier)) (identifier))))
+    (binary_expression
+      (parenthesized_expression (binary_expression (identifier) (identifier)))
+      (identifier)))
+  (if_statement
+    (parenthesized_expression (binary_expression (identifier) (identifier)))
+    (expression_statement (regex))))
 
 ==============================================
 Non-breaking spaces as whitespace
@@ -971,8 +980,8 @@ yield db.users.where('[endpoint+email]')
 (program
   (expression_statement
     (yield_expression
-      (function_call
-        (member_access
-          (member_access (identifier) (property_identifier))
+      (call_expression
+        (member_expression
+          (member_expression (identifier) (property_identifier))
           (property_identifier))
         (arguments (string))))))

--- a/corpus/semicolon_insertion.txt
+++ b/corpus/semicolon_insertion.txt
@@ -12,10 +12,10 @@ if (a) {
 ---
 
 (program
-  (if_statement (identifier) (statement_block
+  (if_statement (parenthesized_expression (identifier)) (statement_block
     (variable_declaration (variable_declarator (identifier) (identifier)))
-    (expression_statement (function_call (identifier) (arguments)))
-    (expression_statement (function_call (identifier) (arguments)))
+    (expression_statement (call_expression (identifier) (arguments)))
+    (expression_statement (call_expression (identifier) (arguments)))
     (return_statement (identifier)))))
 
 ==========================================
@@ -29,8 +29,8 @@ object
 ---
 
 (program (expression_statement
-  (member_access
-    (member_access (identifier) (property_identifier))
+  (member_expression
+    (member_expression (identifier) (property_identifier))
     (property_identifier))))
 
 ===========================================
@@ -72,12 +72,12 @@ a
 ---
 
 (program
-  (expression_statement (ternary (identifier) (identifier) (identifier)))
-  (expression_statement (bool_op (identifier) (identifier)))
-  (expression_statement (bitwise_op (identifier) (identifier)))
-  (expression_statement (rel_op (identifier) (identifier)))
+  (expression_statement (ternary_expression (identifier) (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
   (expression_statement (identifier))
-  (expression_statement (bool_op (identifier)))
+  (expression_statement (unary_expression (identifier)))
   (comment))
 
 ================================================
@@ -108,7 +108,7 @@ a
   (expression_statement (identifier))
   (expression_statement (identifier))
 
-  (expression_statement (type_op (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
 
   (expression_statement (identifier))
   (expression_statement (identifier))
@@ -116,7 +116,7 @@ a
   (expression_statement (identifier))
   (expression_statement (identifier))
 
-  (expression_statement (type_op (identifier) (identifier)))
+  (expression_statement (binary_expression (identifier) (identifier)))
 
   (expression_statement (identifier))
   (expression_statement (identifier)))
@@ -130,7 +130,7 @@ if (a) {b} else {c}
 ---
 
 (program
-  (if_statement (identifier)
+  (if_statement (parenthesized_expression (identifier))
     (statement_block (expression_statement (identifier)))
     (statement_block (expression_statement (identifier)))))
 
@@ -162,11 +162,11 @@ var a = new A()
 (program
   (variable_declaration (variable_declarator
     (identifier)
-    (new_expression (function_call
-      (member_access
-        (function_call
-          (member_access
-            (function_call (identifier) (arguments))
+    (new_expression (call_expression
+      (member_expression
+        (call_expression
+          (member_expression
+            (call_expression (identifier) (arguments))
             (property_identifier))
           (arguments (object (pair (property_identifier) (string)))))
         (property_identifier))
@@ -187,27 +187,29 @@ if (p) { var q }
 ---
 
 (program
-  (if_statement (identifier) (statement_block
+  (if_statement (parenthesized_expression (identifier)) (statement_block
     (if_statement
-      (identifier)
+      (parenthesized_expression (identifier))
       (return_statement (identifier)))))
-  (if_statement (identifier) (statement_block
+  (if_statement (parenthesized_expression (identifier)) (statement_block
     (for_statement
+      (empty_statement)
+      (empty_statement)
       (break_statement))))
-  (if_statement (identifier) (statement_block
+  (if_statement (parenthesized_expression (identifier)) (statement_block
     (for_in_statement (identifier) (identifier)
       (break_statement))))
-  (if_statement (identifier) (statement_block
+  (if_statement (parenthesized_expression (identifier)) (statement_block
     (for_of_statement (identifier) (identifier)
       (continue_statement))))
-  (if_statement (identifier) (statement_block
-    (while_statement (identifier)
+  (if_statement (parenthesized_expression (identifier)) (statement_block
+    (while_statement (parenthesized_expression (identifier))
       (break_statement))))
-  (if_statement (identifier) (statement_block
+  (if_statement (parenthesized_expression (identifier)) (statement_block
     (do_statement
       (statement_block (expression_statement (identifier)))
-      (identifier))))
-  (if_statement (identifier) (statement_block
+      (parenthesized_expression (identifier)))))
+  (if_statement (parenthesized_expression (identifier)) (statement_block
     (variable_declaration (variable_declarator (identifier))))))
 
 =====================================================

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -115,12 +115,12 @@ if (a.b) {
 ----
 
 (program
-  (if_statement (identifier)
-    (expression_statement (function_call
+  (if_statement (parenthesized_expression (identifier))
+    (expression_statement (call_expression
       (identifier) (arguments (identifier)))))
-  (if_statement (member_access (identifier) (property_identifier))
+  (if_statement (parenthesized_expression (member_expression (identifier) (property_identifier)))
     (statement_block
-      (expression_statement (function_call
+      (expression_statement (call_expression
         (identifier) (arguments (identifier))))
       (expression_statement (identifier)))))
 
@@ -143,11 +143,11 @@ if (a) {
 ----
 
 (program
-  (if_statement (identifier)
+  (if_statement (parenthesized_expression (identifier))
     (expression_statement (identifier))
-    (if_statement (identifier)
+    (if_statement (parenthesized_expression (identifier))
       (expression_statement (identifier))))
-  (if_statement (identifier)
+  (if_statement (parenthesized_expression (identifier))
     (statement_block
       (expression_statement (identifier))
       (expression_statement (identifier)))
@@ -176,18 +176,21 @@ for (;;) {
     (variable_declaration
       (variable_declarator (identifier))
       (variable_declarator (identifier)))
-    (identifier)
+    (expression_statement (identifier))
     (identifier)
     (expression_statement (identifier)))
 
   (for_statement
-    (assignment (identifier) (number))
-    (function_call (identifier) (arguments))
-    (rel_op (identifier) (number))
-    (math_op (identifier))
-    (expression_statement (function_call (identifier) (arguments (identifier)))))
+    (expression_statement (sequence_expression
+      (assignment_expression (identifier) (number))
+      (call_expression (identifier) (arguments))))
+    (expression_statement (binary_expression (identifier) (number)))
+    (update_expression (identifier))
+    (expression_statement (call_expression (identifier) (arguments (identifier)))))
 
   (for_statement
+    (empty_statement)
+    (empty_statement)
     (statement_block
       (expression_statement (identifier))
       (continue_statement))))
@@ -206,9 +209,9 @@ for (item in items)
 
 (program
   (for_in_statement (identifier) (identifier)
-    (expression_statement (function_call (identifier) (arguments))))
+    (expression_statement (call_expression (identifier) (arguments))))
   (for_in_statement (identifier) (identifier)
-    (expression_statement (function_call (identifier) (arguments)))))
+    (expression_statement (call_expression (identifier) (arguments)))))
 
 ==========================================
 For loops beginning with an in-expression
@@ -221,13 +224,14 @@ for (key in something && i = 0; i < n; i++) {
 ---
 
 (program (for_statement
-  (bool_op
-    (type_op (identifier) (identifier))
-    (assignment (identifier) (number)))
-  (rel_op (identifier) (identifier))
-  (math_op (identifier))
+  (expression_statement
+    (binary_expression
+      (binary_expression (identifier) (identifier))
+      (assignment_expression (identifier) (number))))
+  (expression_statement (binary_expression (identifier) (identifier)))
+  (update_expression (identifier))
   (statement_block
-    (expression_statement (function_call (identifier) (arguments))))))
+    (expression_statement (call_expression (identifier) (arguments))))))
 
 ============================================
 For-of statements
@@ -240,7 +244,7 @@ for (let item of items)
 
 (program
   (for_of_statement (identifier) (identifier)
-    (expression_statement (function_call (identifier) (arguments (identifier))))))
+    (expression_statement (call_expression (identifier) (arguments (identifier))))))
 
 ============================================
 While statements
@@ -252,8 +256,8 @@ while (a)
 ---
 
 (program
-  (while_statement (identifier)
-    (expression_statement (function_call (identifier) (arguments)))))
+  (while_statement (parenthesized_expression (identifier))
+    (expression_statement (call_expression (identifier) (arguments)))))
 
 ============================================
 Do statements
@@ -268,7 +272,7 @@ do {
 (program
   (do_statement
     (statement_block (expression_statement (identifier)))
-    (identifier)))
+    (parenthesized_expression (identifier))))
 
 ============================================
 Return statements
@@ -285,7 +289,7 @@ return a;
 (program
   (return_statement)
   (return_statement (number))
-  (return_statement (comma_op (number) (number)))
+  (return_statement (sequence_expression (number) (number)))
   (return_statement (identifier))
   (return_statement (identifier)))
 
@@ -363,10 +367,10 @@ var thing = {
         (statement_block
           (comment)
           (expression_statement
-            (function_call (identifier) (arguments)))
+            (call_expression (identifier) (arguments)))
           (comment)
           (expression_statement
-            (function_call (identifier) (arguments))))))))))
+            (call_expression (identifier) (arguments))))))))))
 
 ============================================
 Comments with asterisks
@@ -408,7 +412,7 @@ y // comment
 ---
 
 (program (expression_statement
-  (math_op (identifier) (comment) (identifier))))
+  (binary_expression (identifier) (comment) (identifier))))
 
 ============================================
 Switch statements
@@ -429,16 +433,16 @@ switch (x) {
 ---
 
 (program
-  (switch_statement (identifier)
-    (case (number))
-    (case (number)
-      (expression_statement (function_call (identifier) (arguments)))
+  (switch_statement (parenthesized_expression (identifier)) (switch_body
+    (switch_case (number))
+    (switch_case (number)
+      (expression_statement (call_expression (identifier) (arguments)))
       (break_statement))
-    (case (string)
-      (expression_statement (function_call (identifier) (arguments)))
+    (switch_case (string)
+      (expression_statement (call_expression (identifier) (arguments)))
       (break_statement))
-    (default
-      (return_statement (number)))))
+    (switch_default
+      (return_statement (number))))))
 
 ============================================
 Throw statements
@@ -450,7 +454,7 @@ throw new Error("uh oh");
 
 (program
   (throw_statement
-    (new_expression (function_call (identifier) (arguments (string))))))
+    (new_expression (call_expression (identifier) (arguments (string))))))
 
 ============================================
 Throw statements with sequence expressions
@@ -462,9 +466,9 @@ throw g = 2, g
 
 (program
   (throw_statement
-    (comma_op (assignment (identifier) (number)) (identifier)))
+    (sequence_expression (assignment_expression (identifier) (number)) (identifier)))
   (throw_statement
-    (comma_op (assignment (identifier) (number)) (identifier))))
+    (sequence_expression (assignment_expression (identifier) (number)) (identifier))))
 
 ============================================
 Try catch finally statements
@@ -479,17 +483,17 @@ try { f; } catch { g; } finally { h; }
 (program
   (try_statement
     (statement_block (expression_statement (identifier)))
-    (catch (identifier)
+    (catch_clause (identifier)
       (statement_block (expression_statement (identifier)))))
   (try_statement
     (statement_block (expression_statement (identifier)))
-    (finally
+    (finally_clause
       (statement_block (expression_statement (identifier)))))
   (try_statement
     (statement_block (expression_statement (identifier)))
-    (catch
+    (catch_clause
       (statement_block (expression_statement (identifier))))
-    (finally
+    (finally_clause
       (statement_block (expression_statement (identifier))))))
 
 ============================================
@@ -501,7 +505,7 @@ if (true) { ; };;;
 ---
 
 (program
-  (if_statement (true) (statement_block
+  (if_statement (parenthesized_expression (true)) (statement_block
     (empty_statement)))
   (empty_statement)
   (empty_statement)
@@ -524,10 +528,13 @@ for (;;) {
 
 (program
   (labeled_statement (statement_identifier)
-    (for_statement (statement_block
-      (if_statement (identifier)
-        (statement_block (break_statement (statement_identifier)))
-        (statement_block (continue_statement (statement_identifier))))))))
+    (for_statement
+      (empty_statement)
+      (empty_statement)
+      (statement_block
+        (if_statement (parenthesized_expression (identifier))
+          (statement_block (break_statement (statement_identifier)))
+          (statement_block (continue_statement (statement_identifier))))))))
 
 ============================================
 Debugger statements
@@ -548,4 +555,4 @@ with (x) { i; }
 
 ---
 
-(program (with_statement (identifier) (statement_block (expression_statement (identifier)))))
+(program (with_statement (parenthesized_expression (identifier)) (statement_block (expression_statement (identifier)))))

--- a/grammar.js
+++ b/grammar.js
@@ -739,11 +739,9 @@ module.exports = grammar({
 
     arguments: $ => prec(PREC.CALL, seq(
       '(',
-      commaSep(choice($._expression, $.rest_argument)),
+      commaSep(optional(choice($._expression, $.spread_element))),
       ')'
     )),
-
-    rest_argument: $ => seq('...', $._expression),
 
     class_body: $ => seq(
       '{',

--- a/grammar.js
+++ b/grammar.js
@@ -766,20 +766,12 @@ module.exports = grammar({
       ')'
     ),
 
-    method_definition: $ => choice(
-      seq(
-        optional('async'),
-        optional(choice('get', 'set', '*')),
-        $._property_name,
-        $.formal_parameters,
-        $.statement_block
-      ),
-      seq(
-        optional('async'),
-        optional(choice('get', 'set', '*')),
-        $._property_name,
-        $.formal_parameters
-      )
+    method_definition: $ => seq(
+      optional('async'),
+      optional(choice('get', 'set', '*')),
+      $._property_name,
+      $.formal_parameters,
+      optional($.statement_block)
     ),
 
     pair: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -61,7 +61,6 @@ module.exports = grammar({
       seq('export', $.export_clause, $._from_clause, $._semicolon),
       seq('export', $.export_clause, $._semicolon),
       seq('export', $._declaration),
-      seq('export', 'default', $.anonymous_class),
       seq('export', 'default', $._expression, $._semicolon)
     ),
 
@@ -366,6 +365,7 @@ module.exports = grammar({
       $.jsx_element,
       $.jsx_self_closing_element,
       $.class,
+      $.anonymous_class,
       $.function,
       $.arrow_function,
       $.generator_function,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -96,23 +96,6 @@
             },
             {
               "type": "SYMBOL",
-              "name": "anonymous_class"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "export"
-            },
-            {
-              "type": "STRING",
-              "value": "default"
-            },
-            {
-              "type": "SYMBOL",
               "name": "_expression"
             },
             {
@@ -1361,6 +1344,10 @@
         {
           "type": "SYMBOL",
           "name": "class"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "anonymous_class"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4052,109 +4052,62 @@
       ]
     },
     "method_definition": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "async"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "STRING",
+              "value": "async"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "get"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "set"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "*"
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_property_name"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "formal_parameters"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "statement_block"
+              "type": "BLANK"
             }
           ]
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
               "type": "CHOICE",
               "members": [
                 {
                   "type": "STRING",
-                  "value": "async"
+                  "value": "get"
                 },
                 {
-                  "type": "BLANK"
+                  "type": "STRING",
+                  "value": "set"
+                },
+                {
+                  "type": "STRING",
+                  "value": "*"
                 }
               ]
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "get"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "set"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "*"
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_property_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "formal_parameters"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
             {
               "type": "SYMBOL",
-              "name": "_property_name"
+              "name": "statement_block"
             },
             {
-              "type": "SYMBOL",
-              "name": "formal_parameters"
+              "type": "BLANK"
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -546,7 +546,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "comma_op"
+              "name": "sequence_expression"
             }
           ]
         },
@@ -642,39 +642,30 @@
       ]
     },
     "variable_declarator": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
               "name": "identifier"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_initializer"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_destructuring_pattern"
             }
           ]
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_destructuring_pattern"
+              "name": "_initializer"
             },
             {
-              "type": "SYMBOL",
-              "name": "_initializer"
+              "type": "BLANK"
             }
           ]
         }
@@ -712,7 +703,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_paren_expression"
+            "name": "parenthesized_expression"
           },
           {
             "type": "CHOICE",
@@ -751,53 +742,12 @@
           "value": "switch"
         },
         {
-          "type": "STRING",
-          "value": "("
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        },
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "case"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "default"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        }
-      ]
-    },
-    "_for_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "lexical_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "variable_declaration"
+          "name": "switch_body"
         }
       ]
     },
@@ -817,45 +767,19 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_for_declaration"
+              "name": "lexical_declaration"
             },
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ","
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_expression"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": ";"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "variable_declaration"
             },
             {
-              "type": "STRING",
-              "value": ";"
+              "type": "SYMBOL",
+              "name": "expression_statement"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "empty_statement"
             }
           ]
         },
@@ -864,16 +788,13 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression"
+              "name": "expression_statement"
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "empty_statement"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": ";"
         },
         {
           "type": "CHOICE",
@@ -1022,7 +943,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_paren_expression"
+          "name": "parenthesized_expression"
         },
         {
           "type": "SYMBOL",
@@ -1047,7 +968,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_paren_expression"
+          "name": "parenthesized_expression"
         },
         {
           "type": "SYMBOL",
@@ -1071,7 +992,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "catch"
+              "name": "catch_clause"
             },
             {
               "type": "BLANK"
@@ -1083,7 +1004,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "finally"
+              "name": "finally_clause"
             },
             {
               "type": "BLANK"
@@ -1100,37 +1021,12 @@
           "value": "with"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "("
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                },
-                {
-                  "type": "STRING",
-                  "value": ")"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "statement_block"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_semicolon"
+          "name": "_statement"
         }
       ]
     },
@@ -1226,7 +1122,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "comma_op"
+                  "name": "sequence_expression"
                 }
               ]
             },
@@ -1257,7 +1153,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "comma_op"
+              "name": "sequence_expression"
             }
           ]
         },
@@ -1293,7 +1189,36 @@
         }
       ]
     },
-    "case": {
+    "switch_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "switch_case"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "switch_default"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "switch_case": {
       "type": "SEQ",
       "members": [
         {
@@ -1317,7 +1242,7 @@
         }
       ]
     },
-    "default": {
+    "switch_default": {
       "type": "SEQ",
       "members": [
         {
@@ -1337,7 +1262,7 @@
         }
       ]
     },
-    "catch": {
+    "catch_clause": {
       "type": "SEQ",
       "members": [
         {
@@ -1375,7 +1300,7 @@
         }
       ]
     },
-    "finally": {
+    "finally_clause": {
       "type": "SEQ",
       "members": [
         {
@@ -1388,7 +1313,7 @@
         }
       ]
     },
-    "_paren_expression": {
+    "parenthesized_expression": {
       "type": "SEQ",
       "members": [
         {
@@ -1404,7 +1329,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "comma_op"
+              "name": "sequence_expression"
             }
           ]
         },
@@ -1451,11 +1376,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "function_call"
+          "name": "assignment_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "new_expression"
+          "name": "augmented_assignment_expression"
         },
         {
           "type": "SYMBOL",
@@ -1463,55 +1388,43 @@
         },
         {
           "type": "SYMBOL",
-          "name": "member_access"
+          "name": "binary_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "subscript_access"
+          "name": "unary_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "assignment"
+          "name": "update_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "math_assignment"
+          "name": "call_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "ternary"
+          "name": "member_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "bool_op"
+          "name": "new_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "math_op"
+          "name": "parenthesized_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "bitwise_op"
+          "name": "subscript_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "rel_op"
+          "name": "ternary_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "type_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "delete_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "void_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_paren_expression"
+          "name": "yield_expression"
         },
         {
           "type": "SYMBOL",
@@ -1548,10 +1461,6 @@
         {
           "type": "SYMBOL",
           "name": "undefined"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "yield_expression"
         },
         {
           "type": "SYMBOL",
@@ -1795,7 +1704,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "comma_op"
+              "name": "sequence_expression"
             },
             {
               "type": "SYMBOL",
@@ -1995,20 +1904,27 @@
       ]
     },
     "anonymous_class": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "class"
+              "type": "SYMBOL",
+              "name": "class_heritage"
             },
             {
-              "type": "SYMBOL",
-              "name": "_class_tail"
+              "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class_body"
         }
       ]
     },
@@ -2023,15 +1939,6 @@
           "type": "SYMBOL",
           "name": "identifier"
         },
-        {
-          "type": "SYMBOL",
-          "name": "_class_tail"
-        }
-      ]
-    },
-    "_class_tail": {
-      "type": "SEQ",
-      "members": [
         {
           "type": "CHOICE",
           "members": [
@@ -2192,7 +2099,7 @@
         }
       ]
     },
-    "function_call": {
+    "call_expression": {
       "type": "PREC",
       "value": 12,
       "content": {
@@ -2261,7 +2168,7 @@
         }
       ]
     },
-    "member_access": {
+    "member_expression": {
       "type": "PREC",
       "value": 13,
       "content": {
@@ -2287,7 +2194,7 @@
         ]
       }
     },
-    "subscript_access": {
+    "subscript_expression": {
       "type": "PREC_RIGHT",
       "value": 13,
       "content": {
@@ -2312,7 +2219,7 @@
         ]
       }
     },
-    "assignment": {
+    "assignment_expression": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -2323,11 +2230,11 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "member_access"
+                "name": "member_expression"
               },
               {
                 "type": "SYMBOL",
-                "name": "subscript_access"
+                "name": "subscript_expression"
               },
               {
                 "type": "SYMBOL",
@@ -2346,20 +2253,7 @@
         ]
       }
     },
-    "_initializer": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "="
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        }
-      ]
-    },
-    "math_assignment": {
+    "augmented_assignment_expression": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -2370,15 +2264,15 @@
             "members": [
               {
                 "type": "SYMBOL",
+                "name": "member_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "subscript_expression"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "member_access"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "subscript_access"
               }
             ]
           },
@@ -2426,6 +2320,19 @@
         ]
       }
     },
+    "_initializer": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        }
+      ]
+    },
     "_destructuring_pattern": {
       "type": "CHOICE",
       "members": [
@@ -2462,7 +2369,7 @@
         }
       ]
     },
-    "ternary": {
+    "ternary_expression": {
       "type": "PREC_RIGHT",
       "value": 1,
       "content": {
@@ -2491,26 +2398,9 @@
         ]
       }
     },
-    "bool_op": {
+    "binary_expression": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "PREC_LEFT",
-          "value": 8,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "!"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
         {
           "type": "PREC_LEFT",
           "value": 3,
@@ -2545,28 +2435,6 @@
               {
                 "type": "STRING",
                 "value": "||"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "bitwise_op": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC_LEFT",
-          "value": 8,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "~"
               },
               {
                 "type": "SYMBOL",
@@ -2763,113 +2631,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "math_op": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC_LEFT",
-          "value": 9,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "-"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 9,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "+"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 10,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "STRING",
-                "value": "++"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 10,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              },
-              {
-                "type": "STRING",
-                "value": "--"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 10,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "++"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 10,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "--"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
         },
         {
           "type": "PREC_LEFT",
@@ -2975,85 +2736,7 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "delete_op": {
-      "type": "PREC",
-      "value": 7,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "delete"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "member_access"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "subscript_access"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "void_op": {
-      "type": "PREC",
-      "value": 7,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "void"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          }
-        ]
-      }
-    },
-    "comma_op": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          },
-          {
-            "type": "STRING",
-            "value": ","
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "comma_op"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "rel_op": {
-      "type": "CHOICE",
-      "members": [
+        },
         {
           "type": "PREC_LEFT",
           "value": 5,
@@ -3221,28 +2904,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "type_op": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC",
-          "value": 7,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "typeof"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
         },
         {
           "type": "PREC_LEFT",
@@ -3287,6 +2948,221 @@
           }
         }
       ]
+    },
+    "unary_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": 8,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "!"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 8,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "~"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 9,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "-"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 9,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "+"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 7,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "typeof"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 7,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "void"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 7,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "delete"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "update_expression": {
+      "type": "PREC_LEFT",
+      "value": 10,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "STRING",
+                "value": "++"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "STRING",
+                "value": "--"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "++"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "--"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "sequence_expression": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "STRING",
+            "value": ","
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "sequence_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        ]
+      }
     },
     "comment": {
       "type": "TOKEN",
@@ -3460,7 +3336,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "comma_op"
+              "name": "sequence_expression"
             }
           ]
         },
@@ -4377,7 +4253,7 @@
     ],
     [
       "assignment_pattern",
-      "assignment"
+      "assignment_expression"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3830,12 +3830,20 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "_expression"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "spread_element"
+                          }
+                        ]
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "rest_argument"
+                        "type": "BLANK"
                       }
                     ]
                   },
@@ -3852,12 +3860,20 @@
                           "type": "CHOICE",
                           "members": [
                             {
-                              "type": "SYMBOL",
-                              "name": "_expression"
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_expression"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "spread_element"
+                                }
+                              ]
                             },
                             {
-                              "type": "SYMBOL",
-                              "name": "rest_argument"
+                              "type": "BLANK"
                             }
                           ]
                         }
@@ -3877,19 +3893,6 @@
           }
         ]
       }
-    },
-    "rest_argument": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "..."
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        }
-      ]
     },
     "class_body": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1388,11 +1388,15 @@
         },
         {
           "type": "SYMBOL",
+          "name": "unary_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "binary_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "unary_expression"
+          "name": "ternary_expression"
         },
         {
           "type": "SYMBOL",
@@ -1417,10 +1421,6 @@
         {
           "type": "SYMBOL",
           "name": "subscript_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ternary_expression"
         },
         {
           "type": "SYMBOL",
@@ -1516,8 +1516,115 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_property_definition_list"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "pair"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "spread_element"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "method_definition"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "assignment_pattern"
+                          },
+                          {
+                            "type": "ALIAS",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "identifier"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_reserved_identifier"
+                                }
+                              ]
+                            },
+                            "named": true,
+                            "value": "shorthand_property_identifier"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "pair"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "spread_element"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "method_definition"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "assignment_pattern"
+                                },
+                                {
+                                  "type": "ALIAS",
+                                  "content": {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SYMBOL",
+                                        "name": "identifier"
+                                      },
+                                      {
+                                        "type": "SYMBOL",
+                                        "name": "_reserved_identifier"
+                                      }
+                                    ]
+                                  },
+                                  "named": true,
+                                  "value": "shorthand_property_identifier"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -1530,79 +1637,6 @@
           }
         ]
       }
-    },
-    "_property_definition_list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "pair"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_definition"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_reserved_identifier"
-                  }
-                ]
-              },
-              "named": true,
-              "value": "shorthand_property_identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "spread_element"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "assignment_pattern"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_property_definition_list"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
     },
     "assignment_pattern": {
       "type": "SEQ",
@@ -1633,8 +1667,63 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_element_list"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expression"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "spread_element"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "_expression"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "spread_element"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1834,70 +1923,6 @@
             },
             {
               "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "_element_list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "spread_element"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_element_list"
-                        },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
             }
           ]
         }
@@ -4242,10 +4267,6 @@
     [
       "_expression",
       "formal_parameters"
-    ],
-    [
-      "_expression",
-      "_property_definition_list"
     ],
     [
       "labeled_statement",


### PR DESCRIPTION
This simplifies the structure of expressions so that they more closely match the ESTree spec, as well as other tree-sitter grammars.

* Binary expressions, which were formerly divided up in a somewhat ad-hoc way into `math_op`, `bool_op`, `rel_op`, `bitwise_op`, etc, are now all called `binary_expression`.
* Unary expressions, which were formerly mixed into the aforementioned rules, are now all called `unary_expression`.
* `function_call` -> `call_expression`
* `member_access` -> `member_expression`
* `subscript_access` -> `subscript_expression`
* `assignment` -> `assignment_expression`
* `math_assignment` -> `augmented_assignment_expression`

In addition, I've made several changes to statement rules which make the statement's structure more clear:

* Replaced the invisible `_paren_expression` rule with a *visible* `parenthesized_expression`
* Switch statements' bodies are now visible as `switch_body`.
* For statements initializers and conditions are now always named (though they may be `empty_statements`).

/cc @tclem