### PR TITLE
Alias _template_chars to string

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -39,23 +39,30 @@ Template strings
 ----
 
 (program
-  (expression_statement (template_string))
-  (expression_statement (template_string))
+  (expression_statement (template_string (string)))
+  (expression_statement (template_string (string)))
   (expression_statement (template_string
+    (string)
     (template_substitution
       (binary_expression (number) (number)))
+    (string)
     (template_substitution (sequence_expression
       (binary_expression (number) (number))
-      (binary_expression (number) (number))))))
-  (expression_statement (template_string))
+      (binary_expression (number) (number))))
+    (string)))
+  (expression_statement (template_string (string)))
   (expression_statement (template_string
+    (string)
     (template_substitution (number))))
-	(expression_statement (template_string))
+	(expression_statement (template_string (string)))
   (expression_statement (template_string
+    (string)
     (template_substitution (call_expression
       (member_expression (identifier) (property_identifier))
       (arguments (string))))
-    (template_substitution (identifier)))))
+    (string)
+    (template_substitution (identifier))
+    (string))))
 
 ============================================
 Function calls with template strings
@@ -66,7 +73,7 @@ f `hello`;
 ---
 
 (program
-  (expression_statement (call_expression (identifier) (template_string))))
+  (expression_statement (call_expression (identifier) (template_string (string)))))
 
 ============================================
 Numbers

--- a/grammar.js
+++ b/grammar.js
@@ -668,11 +668,11 @@ module.exports = grammar({
       '`'
     ),
 
-    _template_chars: $ => token(repeat1(choice(
+    _template_chars: $ => alias(token(repeat1(choice(
       /[^`\$]/,
       /\$[^{]/,
       /\\`/
-    ))),
+    ))), $.string),
 
     template_substitution: $ => seq(
       '${',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3310,27 +3310,32 @@
       ]
     },
     "_template_chars": {
-      "type": "TOKEN",
+      "type": "ALIAS",
       "content": {
-        "type": "REPEAT1",
+        "type": "TOKEN",
         "content": {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "[^`\\$]"
-            },
-            {
-              "type": "PATTERN",
-              "value": "\\$[^{]"
-            },
-            {
-              "type": "PATTERN",
-              "value": "\\\\`"
-            }
-          ]
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[^`\\$]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\$[^{]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\`"
+              }
+            ]
+          }
         }
-      }
+      },
+      "named": true,
+      "value": "string"
     },
     "template_substitution": {
       "type": "SEQ",


### PR DESCRIPTION
In order to parse string content in template strings, we need explicit nodes for them.