### PR TITLE
Allow automatic semicolon insertion before comments

### DIFF
--- a/corpus/semicolon_insertion.txt
+++ b/corpus/semicolon_insertion.txt
@@ -225,3 +225,33 @@ function a () { function b () {} function *c () {} class D {} return }
     (generator_function (identifier) (formal_parameters) (statement_block))
     (class (identifier) (class_body))
     (return_statement))))
+
+=====================================================
+Comments after statements without semicolons
+=====================================================
+
+let a // comment at end of declaration
+
+// comment outside of declaration
+let b /* comment between declarators */, c
+
+/** comment with *stars* **/ /* comment with /slashes/ */
+/* third comment in a row */
+
+let d
+
+---
+
+(program
+  (lexical_declaration
+    (variable_declarator (identifier))
+    (comment))
+  (comment)
+  (lexical_declaration
+    (variable_declarator (identifier))
+    (comment)
+    (variable_declarator (identifier)))
+  (comment)
+  (comment)
+  (comment)
+  (lexical_declaration (variable_declarator (identifier))))


### PR DESCRIPTION
In code like this:

```js
foo()

// comment 1
// comment 2

bar()
```

an 'automatic semicolon' token should be inserted right after `foo()`. This requires that the lexer look ahead quite a bit - it needs to see what's *after* the run of comments, because there might be something like this:


```js
foo()

// comment 1
// comment 2

  .bar()
```

In this latter case, there should *not* be an automatic semicolon after `foo()`.

This PR implements that behavior. I don't think there will be much performance cost to this extra lookahead; the actual character-by-character scanning never contributes much to tree-sitter's parse time. 

/cc @robrix - We'll need to do this same thing in the typescript scanner.