### PR TITLE
Statement block isn't optional in method body

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -771,7 +771,7 @@ module.exports = grammar({
       optional(choice('get', 'set', '*')),
       $._property_name,
       $.formal_parameters,
-      optional($.statement_block)
+      $.statement_block
     ),
 
     pair: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4087,16 +4087,8 @@
           "name": "formal_parameters"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "statement_block"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "statement_block"
         }
       ]
     },


### PR DESCRIPTION
This was causing an issue where something like:
```javascript
  if (foo) {
    performHealthcheck()
  }

```

was parsing as:

```lisp
(if_statement
              (parenthesized_expression
                (expression))
              (expression_statement
                (object
                  (method_definition
                    (property_identifier
                    (call_signature
                      (formal_parameters)))))))
```
/cc @maxbrunsfeld 