### PR TITLE
Make example parsing not use submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 *.log
 package-lock.json
 /test.js
+/examples/npm

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "examples/npm"]
-	path = examples/npm
-	url = https://github.com/npm/npm

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -4,14 +4,17 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+
+# Clone npm/npm and check out a known sha
 repo=examples/npm
 
-if [ -d "$repo" ]; then
-  pushd "$repo" && git pull
-  popd
-else
+if [ ! -d "$repo" ]; then
   git clone https://github.com/npm/npm "$repo"
 fi
+
+pushd "$repo" && git pull
+git reset --hard ee147fbbca6f2707d3b16f4fa78f4c4606b2d9b1
+popd
 
 tree-sitter parse examples/*.js -q
 

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -2,12 +2,23 @@
 
 set -e
 
+cd "$(dirname "$0")/.."
+
+repo=examples/npm
+
+if [ -d "$repo" ]; then
+  pushd "$repo" && git pull
+  popd
+else
+  git clone https://github.com/npm/npm "$repo"
+fi
+
 tree-sitter parse examples/*.js -q
 
 # TODO: Fix known issues in known_failures.txt
 known_failures=$(cat script/known_failures.txt)
 examples_to_parse=$(
-  for example in $(find examples/npm -name '*.js'); do
+  for example in $(find "$repo" -name '*.js'); do
     if [[ ! $known_failures == *$example* ]]; then
       echo $example
     fi


### PR DESCRIPTION
Running into some `Path too long` issues over the Windows build of https://github.com/tree-sitter/tree-sitter-typescript/pull/57. Try to parse examples without including example repos as submodules.