### PR TITLE
Insert automatic semicolons at included range boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "acorn": "^2.6.4",
     "babylon": "^6.3.26",
     "esprima": "^2.7.1",
-    "tree-sitter-cli": "^0.12.6"
+    "tree-sitter-cli": "^0.13.1"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,7 +5,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#define LANGUAGE_VERSION 8
+#define LANGUAGE_VERSION 9
 #define STATE_COUNT 1861
 #define SYMBOL_COUNT 210
 #define ALIAS_COUNT 10

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -81,6 +81,7 @@ bool tree_sitter_javascript_external_scanner_scan(void *payload, TSLexer *lexer,
     for (;;) {
       if (lexer->lookahead == 0) return true;
       if (lexer->lookahead == '}') return true;
+      if (lexer->is_at_included_range_start(lexer)) return true;
       if (!iswspace(lexer->lookahead)) return false;
       if (lexer->lookahead == '\n') break;
       advance(lexer);

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -25,13 +25,16 @@ typedef struct {
   bool named : 1;
 } TSSymbolMetadata;
 
-typedef struct {
-  void (*advance)(void *, bool);
-  void (*mark_end)(void *);
-  uint32_t (*get_column)(void *);
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
   int32_t lookahead;
   TSSymbol result_symbol;
-} TSLexer;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(TSLexer *);
+};
 
 typedef enum {
   TSParseActionTypeShift,


### PR DESCRIPTION
Depends on https://github.com/tree-sitter/tree-sitter/pull/183

This prevent parse errors when parsing EJS code like this:

```ejs
<div id=<%= getId() %>><%= getContent() %></div>
```