### PR TITLE
Remove known failures that now parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.node-version
 build
 *.log
 /test.js

--- a/script/known_failures.txt
+++ b/script/known_failures.txt
@@ -1,6 +1,1 @@
 examples/npm/node_modules/slide/lib/async-map-ordered.js
-examples/npm/node_modules/unique-filename/coverage/prettify.js
-examples/npm/node_modules/read/node_modules/mute-stream/coverage/lcov-report/prettify.js
-examples/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/dist/nodent.min.js
-examples/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/dist/ajv.min.js
-examples/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/dist/regenerator.min.js


### PR DESCRIPTION
While pairing with @tclem and @maxbrunsfeld today we saw that several of the known failures from npm now parse.

This pull request removes them from the list.