### PR TITLE
A label can have a cr before the colon

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -680,6 +680,11 @@ for (;;) {
   }
 }
 
+label
+: {
+  break label;
+}
+
 ---
 
 (program
@@ -694,7 +699,11 @@ for (;;) {
           consequence: (statement_block
             (break_statement label: (statement_identifier)))
           alternative: (statement_block
-            (continue_statement label: (statement_identifier))))))))
+            (continue_statement label: (statement_identifier)))))))
+    (labeled_statement
+      label: (statement_identifier)
+      (statement_block
+        (break_statement label: (statement_identifier)))))
 
 ============================================
 Debugger statements

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -92,6 +92,7 @@ bool tree_sitter_javascript_external_scanner_scan(void *payload, TSLexer *lexer,
     switch (lexer->lookahead) {
       case ',':
       case '.':
+      case ':':
       case ';':
       case '*':
       case '%':


### PR DESCRIPTION
Because of automatic_semicolon, a label can't have a cr after it:
https://searchfox.org/mozilla-central/source/js/src/jsapi-tests/binast/parser/multipart/spidermonkey/ecma_2/Statements/label-003.js