### PR TITLE
Update tags query, add new prefixes to capture names

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -21,14 +21,14 @@
 (
   (comment)* @doc
   [
-  (function
-    name: (identifier) @name)
-  (function_declaration
-    name: (identifier) @name)
-  (generator_function
-    name: (identifier) @name)
-  (generator_function_declaration
-    name: (identifier) @name)
+    (function
+      name: (identifier) @name)
+    (function_declaration
+      name: (identifier) @name)
+    (generator_function
+      name: (identifier) @name)
+    (generator_function_declaration
+      name: (identifier) @name)
   ] @definition.function
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
   (#select-adjacent! @doc @definition.function)

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,53 +1,36 @@
 (
   (comment)* @doc
   (method_definition
-    name: (property_identifier) @name) @method
+    name: (property_identifier) @name) @definition.method
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
-  (#select-adjacent! @doc @method)
-)
-
-(
-
-  (comment)* @doc
-  (class
-    name: (identifier) @name) @class
-  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
-  (#select-adjacent! @doc @class)
+  (#select-adjacent! @doc @definition.method)
 )
 
 (
   (comment)* @doc
-  (class_declaration
-    name: (identifier) @name) @class
+  [
+    (class
+      name: (identifier) @name)
+    (class_declaration
+      name: (identifier) @name)
+  ] @definition.class
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
-  (#select-adjacent! @doc @class)
+  (#select-adjacent! @doc @definition.class)
 )
-
 
 (
   (comment)+? @doc
   (lexical_declaration
     (variable_declarator
       name: (identifier) @name
-      value: (arrow_function)) @function)
+      value: [(arrow_function) (function)]) @definition.function)
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
-  (#select-adjacent! @doc @function)
-)
-
-(
-  (comment)* @doc
-  (lexical_declaration
-    (variable_declarator
-      name: (identifier) @name
-      value: (function)) @function)
-  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
-  (#select-adjacent! @doc @function)
+  (#select-adjacent! @doc @definition.function)
 )
 
 (call_expression
-  function: (identifier) @name) @call
+  function: (identifier) @name) @reference.call
 
 (call_expression
   function: (member_expression
-    property: (property_identifier) @name)) @call
-
+    property: (property_identifier) @name)) @reference.call

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -50,3 +50,6 @@
 (call_expression
   function: (member_expression
     property: (property_identifier) @name)) @reference.call
+
+(new_expression
+  constructor: (identifier) @name) @reference.class


### PR DESCRIPTION
Tracking some improvements to tree-sitter tagging in https://github.com/tree-sitter/tree-sitter/pull/648, this updates the `tags.scm` to use the new required prefixes. There are a number of other changes we should make here to bring up to speed with [semantic](https://github.com/github/semantic/blob/master/semantic-typescript/src/Language/TypeScript/Tags.hs#L141).