### PR TITLE
Add Rust package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Cargo.lock
 node_modules
 .node-version
 build
@@ -5,3 +6,4 @@ build
 /test.js
 /examples/npm
 package-lock.json
+/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ build = "bindings/rust/build.rs"
 include = [
   "bindings/rust/*",
   "grammar.js",
+  "queries/*",
   "src/*",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "tree-sitter-javascript"
+description = "JavaScript grammar for the tree-sitter parsing library"
+version = "0.16.0"
+authors = [
+    "Max Brunsfeld <maxbrunsfeld@gmail.com>",
+    "Douglas Creager <dcreager@dcreager.net>",
+]
+license = "MIT"
+readme = "bindings/rust/README.md"
+keywords = ["incremental", "parsing", "javascript"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-javascript"
+edition = "2018"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "0.17"
+
+[build-dependencies]
+cc = "1.0"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,0 +1,37 @@
+# tree-sitter-javascript
+
+This crate provides a JavaScript grammar for the [tree-sitter][] parsing
+library.  To use this crate, add it to the `[dependencies]` section of your
+`Cargo.toml` file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-javascript = "0.16"
+```
+
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
+
+``` rust
+let code = r#"
+    function double(x) {
+        return x * 2;
+    }
+"#;
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_javascript::language()).expect("Error loading JavaScript grammar");
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-javascript/*/tree_sitter_javascript/fn.language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser-scanner");
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -46,25 +46,25 @@ pub fn language() -> Language {
 /// The source of the JavaScript tree-sitter grammar description.
 pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
 
-/// The syntax highlighting queries for this language.
-pub const HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights.scm");
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 
-/// The syntax highlighting queries for languages injected into this one.
-pub const INJECTION_QUERIES: &'static str = include_str!("../../queries/injections.scm");
+/// The syntax highlighting query for languages injected into this one.
+pub const INJECTION_QUERY: &'static str = include_str!("../../queries/injections.scm");
 
-/// The syntax highlighting queries for JSX.
-pub const JSX_HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights-jsx.scm");
+/// The syntax highlighting query for JSX.
+pub const JSX_HIGHLIGHT_QUERY: &'static str = include_str!("../../queries/highlights-jsx.scm");
 
-/// The local-variable syntax highlighting queries for this language.
-pub const LOCALS_QUERIES: &'static str = include_str!("../../queries/locals.scm");
+/// The local-variable syntax highlighting query for this language.
+pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
-/// The symbol tagging queries for this language.
-pub const TAGGING_QUERIES: &'static str = include_str!("../../queries/tags.scm");
+/// The symbol tagging query for this language.
+pub const TAGGING_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -46,10 +46,25 @@ pub fn language() -> Language {
 /// The source of the JavaScript tree-sitter grammar description.
 pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
 
+/// The syntax highlighting queries for this language.
+pub const HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights.scm");
+
+/// The syntax highlighting queries for languages injected into this one.
+pub const INJECTION_QUERIES: &'static str = include_str!("../../queries/injections.scm");
+
+/// The syntax highlighting queries for JSX.
+pub const JSX_HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights-jsx.scm");
+
+/// The local-variable syntax highlighting queries for this language.
+pub const LOCALS_QUERIES: &'static str = include_str!("../../queries/locals.scm");
+
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+/// The symbol tagging queries for this language.
+pub const TAGGING_QUERIES: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,63 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2020, tree-sitter-javascript authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a JavaScript grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//!     function double(x) {
+//!         return x * 2;
+//!     }
+//! "#;
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_javascript::language()).expect("Error loading JavaScript grammar");
+//! let parsed = parser.parse(code, None);
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_javascript() -> Language;
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_javascript() }
+}
+
+/// The source of the JavaScript tree-sitter grammar description.
+pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading JavaScript grammar");
+    }
+}


### PR DESCRIPTION
This adds a Rust package for this language grammar.  This makes it easier to use the Rust tree-sitter bindings with a statically known set of languages, since you can just list them as normal Rust dependencies, instead of having to embed the grammar and set up a build.rs file yourself.