### PR TITLE
Use empty_statement

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5521,8 +5521,8 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": ";"
+                        "type": "SYMBOL",
+                        "name": "empty_statement"
                       },
                       {
                         "type": "BLANK"


### PR DESCRIPTION
I was using ```ctrl+f``` with ```";"```, when I saw that empty_statement and class_body had the same thing.

Very simple pr