### PR TITLE
Fix "ambiguous argument 'head'" error in test script and make future errors fatal.

### DIFF
--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 cd "$(dirname "$0")/.."
 
@@ -16,7 +16,8 @@ function clone_repo {
   fi
 
   pushd "$path" > /dev/null
-  if [ "$(git rev-parse head)" != "$sha"  ]; then
+  actual_sha=$(git rev-parse HEAD)
+  if [ "$actual_sha" != "$sha"  ]; then
     echo "Updating $owner/$name to $sha"
     git fetch
     git reset --hard $sha


### PR DESCRIPTION
`git rev-parse head` was failing, causing a `git clone` every time. Taking it out of the `if` condition makes the shell script fail if this occurs again, instead of proceeding as previously.