### PR TITLE
Add two issue templates: bug report and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report unexpected parsing results
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+The following piece of code is valid but it is parsed incorrectly:
+
+```javascript
+
+```
+
+Here's a link to the TypeScript Playground showing that the snippet above is valid JavaScript or TypeScript:
+<!-- Please check your code at https://www.typescriptlang.org/play
+     and paste the URL below. -->
+
+<!-- Please run `tree-sitter parse YOUR_FILE` and show us the output. -->
+The output of `tree-sitter parse` is the following:
+
+```
+
+```
+
+<!-- If there is no `ERROR` or `MISSING` node in the output above,
+     explain what you were expecting: -->
+
+<!-- Name of the broken/missing feature, link to official
+     documentation, and any other relevant info is appreciated: -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+     The tree-sitter-javascript project is a JavaScript and JSX parser only.
+     How can we improve it?
+-->


### PR DESCRIPTION
I'd like to add issue templates. This is intended to:
* minimize reports for the wrong project
* save time by having the reporter share what they already know

If we're happy with this, I'll make something similar for tree-sitter-typescript.

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
