### PR TITLE
0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-javascript"
 description = "JavaScript grammar for the tree-sitter parsing library"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
     "Max Brunsfeld <maxbrunsfeld@gmail.com>",
     "Douglas Creager <dcreager@dcreager.net>",
@@ -25,7 +25,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-javascript",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Javascript grammar for node-tree-sitter",
   "main": "bindings/node",
   "keywords": [
@@ -17,7 +17,7 @@
     "nan": "^2.12.1"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.2"
+    "tree-sitter-cli": "^0.20.0"
   },
   "scripts": {
     "test": "tree-sitter test && script/parse-examples",


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI.
- [ ] The script/parse-examples passes without issues.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).

This PR updates `tree-sitter-javascript` to 0.20

@maxbrunsfeld 

Can we release it on crates.io also? Thanks in advance! :)
