### PR TITLE
Loosen Rust crate's tree-sitter dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20"
+tree-sitter = ">= 0.19, < 0.21"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Nothing in the Rust binding depends on tree-sitter 0.20 in particular; it works just fine if you haven't updated from 0.19 yet.  (Other versions might work as well; these are the only two that I tested.)