### PR TITLE
Add unit tests for tags queries

### DIFF
--- a/test/tags/classes.js
+++ b/test/tags/classes.js
@@ -1,0 +1,14 @@
+class Person {
+  //   ^ definition.class
+  static foo = bar;
+
+  getName() {
+    // ^ definition.method
+  }
+}
+
+var person = new Person();
+//                ^ reference.class
+
+person.getName()
+//      ^ reference.call

--- a/test/tags/functions.js
+++ b/test/tags/functions.js
@@ -1,0 +1,22 @@
+function foo() {
+  //      ^ definition.function
+}
+
+foo()
+// <- reference.call
+
+{ source: $ => repeat($._expression) }
+// ^ definition.function
+//              ^ reference.call
+
+let plus1 = x => x + 1
+//   ^ definition.function
+
+let plus2 = function(x) { return x + 2 }
+//   ^ definition.function
+
+function *gen() { }
+//         ^ definition.function
+
+async function* foo() { yield 1; }
+//               ^ definition.function


### PR DESCRIPTION
Checklist: ✅ 
- [x] All tests pass in CI.
- [x] The script/parse-examples passes without issues.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).

(mostly doesn't apply as this PR just adds new unit tests)

Following up on https://github.com/tree-sitter/tree-sitter/pull/1547, this PR adds unit tests for the tags queries. Let me know if there are edge cases I missed!

~Also included is a bump to tree-sitter-cli v0.20.6 which has the new tags testing code.~
