### PR TITLE
Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 /examples/npm
 package-lock.json
 /target/
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterJS",
+    products: [
+        .library(name: "TreeSitterJS", targets: ["TreeSitterJS"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterJS",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "README.md",
+                    "script",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                    "*.wasm",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterJS/javascript.h
+++ b/bindings/swift/TreeSitterJS/javascript.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_JAVASCRIPT_H_
+#define TREE_SITTER_JAVASCRIPT_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_javascript();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_JAVASCRIPT_H_ 


### PR DESCRIPTION
Swift's package manager can build C/C++ sources and use headers to expose functions to Swift. The standard tree-sitter parser project layout just requires a little extra configuration to make it happy.
