### PR TITLE
fix: exponentation operator ** is right associative

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -810,7 +810,7 @@ module.exports = grammar({
         ['*', 'binary_times'],
         ['/', 'binary_times'],
         ['%', 'binary_times'],
-        ['**', 'binary_exp'],
+        ['**', 'binary_exp', 'right'],
         ['<', 'binary_relation'],
         ['<=', 'binary_relation'],
         ['==', 'binary_equality'],
@@ -822,8 +822,8 @@ module.exports = grammar({
         ['??', 'ternary'],
         ['instanceof', 'binary_relation'],
         ['in', 'binary_relation'],
-      ].map(([operator, precedence]) =>
-        prec.left(precedence, seq(
+      ].map(([operator, precedence, associativity]) =>
+        (associativity === 'right' ? prec.right : prec.left)(precedence, seq(
           field('left', $.expression),
           field('operator', operator),
           field('right', $.expression)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -902,6 +902,7 @@ i--;
 i + j * 3 - j % 5;
 2 ** i * 3;
 2 * i ** 3;
+2 ** i ** 3;
 +x;
 -x;
 
@@ -918,6 +919,9 @@ i + j * 3 - j % 5;
   (expression_statement (binary_expression
     (binary_expression (number) (identifier))
     (number)))
+  (expression_statement (binary_expression
+    (number)
+    (binary_expression (identifier) (number))))
   (expression_statement (binary_expression
     (number)
     (binary_expression (identifier) (number))))


### PR DESCRIPTION
Addresses https://github.com/tree-sitter/tree-sitter-javascript/issues/210

Checklist:
- [ ] All tests pass in CI.
- [x] The script/parse-examples passes without issues.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
