### PR TITLE
Add action to automatically publish crate

### DIFF
--- a/publish_crate.yml
+++ b/publish_crate.yml
@@ -1,0 +1,36 @@
+name: Publish on crates.io
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Verify publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          dry-run: true
+
+      - name: Publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Following other grammar repositories, add an action that automatically publishes the crate when a version tag is pushed.
