### PR TITLE
Adds Blackbird queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -86,3 +86,14 @@
 
 (new_expression
   constructor: (_) @name) @reference.class
+
+(export_statement value: (assignment_expression left: (identifier) @name right: ([
+ (number)
+ (string)
+ (identifier)
+ (undefined)
+ (null)
+ (new_expression)
+ (binary_expression)
+ (call_expression)
+]))) @definition.constant


### PR DESCRIPTION
This PR adds queries to support GH code search.

Blackbird is the name of the GH code search tool that `tags.scm` was intended to support. For some reason the code search team was not using ts-internal tag queries and was instead using their own custom queries and we're now moving those queries upstream so that any service that wants to index name symbols in a way consistent with other services can rely on the tag queries.

Checklist:
- [ ] All tests pass in CI.
- [ ] The script/parse-examples passes without issues.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
