### PR TITLE
Fix: Comment optimization should not cause automatic-semi insert for single-line block

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -48,9 +48,9 @@ static bool scan_template_chars(TSLexer *lexer) {
 }
 
 enum WhitespaceResult {
-    REJECT,
+    REJECT, // Semicolon is illegal, ie a syntax error occurred
     NO_NEWLINE, // Unclear if semicolon will be legal, continue
-    ACCEPT, // Semicolon is legal due to comment
+    ACCEPT, // Semicolon is legal, assuming a comment was encountered
 };
 
 /**

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -47,16 +47,16 @@ static bool scan_template_chars(TSLexer *lexer) {
     }
 }
 
-enum WhitespaceResult {
+typedef enum {
     REJECT,     // Semicolon is illegal, ie a syntax error occurred
     NO_NEWLINE, // Unclear if semicolon will be legal, continue
     ACCEPT,     // Semicolon is legal, assuming a comment was encountered
-};
+} WhitespaceResult;
 
 /**
  * @param consume If false, only consume enough to check if comment indicates semicolon-legality
  */
-static enum WhitespaceResult scan_whitespace_and_comments(TSLexer *lexer, bool *scanned_comment, bool consume) {
+static WhitespaceResult scan_whitespace_and_comments(TSLexer *lexer, bool *scanned_comment, bool consume) {
     bool saw_block_newline = false;
 
     for (;;) {
@@ -115,7 +115,7 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
         }
 
         if (lexer->lookahead == '/') {
-            enum WhitespaceResult result = scan_whitespace_and_comments(lexer, scanned_comment, false);
+            WhitespaceResult result = scan_whitespace_and_comments(lexer, scanned_comment, false);
             if (result == REJECT) {
                 return false;
             }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -48,9 +48,9 @@ static bool scan_template_chars(TSLexer *lexer) {
 }
 
 enum WhitespaceResult {
-    REJECT, // Semicolon is illegal, ie a syntax error occurred
+    REJECT,     // Semicolon is illegal, ie a syntax error occurred
     NO_NEWLINE, // Unclear if semicolon will be legal, continue
-    ACCEPT, // Semicolon is legal, assuming a comment was encountered
+    ACCEPT,     // Semicolon is legal, assuming a comment was encountered
 };
 
 /**
@@ -83,14 +83,13 @@ static enum WhitespaceResult scan_whitespace_and_comments(TSLexer *lexer, bool *
                             skip(lexer);
                             *scanned_comment = true;
 
-                            if(lexer->lookahead != '/' && !consume){
+                            if (lexer->lookahead != '/' && !consume) {
                                 return saw_block_newline ? ACCEPT : NO_NEWLINE;
                             }
 
                             break;
                         }
-                    } else if (lexer->lookahead == '\n' || lexer->lookahead == 0x2028 ||
-                               lexer->lookahead == 0x2029) {
+                    } else if (lexer->lookahead == '\n' || lexer->lookahead == 0x2028 || lexer->lookahead == 0x2029) {
                         saw_block_newline = true;
                         skip(lexer);
                     } else {
@@ -115,7 +114,6 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
             return true;
         }
 
-
         if (lexer->lookahead == '/') {
             enum WhitespaceResult result = scan_whitespace_and_comments(lexer, scanned_comment, false);
             if (result == REJECT) {
@@ -125,7 +123,6 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
             if (result == ACCEPT && comment_condition && lexer->lookahead != ',' && lexer->lookahead != '=') {
                 return true;
             }
-            
         }
 
         if (lexer->lookahead == '}') {
@@ -148,8 +145,6 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
     }
 
     skip(lexer);
-
-
 
     if (scan_whitespace_and_comments(lexer, scanned_comment, true) == REJECT) {
         return false;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -96,13 +96,13 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
     lexer->result_symbol = AUTOMATIC_SEMICOLON;
     lexer->mark_end(lexer);
 
-    bool saw_single_block_comment = true;
     for (;;) {
         if (lexer->lookahead == 0) {
             return true;
         }
 
         if (lexer->lookahead == '/') {
+            bool saw_single_block_comment = false;
             if (!scan_whitespace_and_comments(lexer, scanned_comment, &saw_single_block_comment)) {
                 return false;
             }
@@ -135,7 +135,8 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
 
 
 
-    if (!scan_whitespace_and_comments(lexer, scanned_comment, &saw_single_block_comment)) {
+    bool unused = false;
+    if (!scan_whitespace_and_comments(lexer, scanned_comment, &unused)) {
         return false;
     }
 

--- a/test/corpus/semicolon_insertion.txt
+++ b/test/corpus/semicolon_insertion.txt
@@ -276,8 +276,8 @@ let d
 
 (program
   (lexical_declaration
-    (variable_declarator (identifier))
-  (comment))
+    (variable_declarator (identifier)))
+  (comment)
   (comment)
   (lexical_declaration
     (variable_declarator (identifier))

--- a/test/corpus/semicolon_insertion.txt
+++ b/test/corpus/semicolon_insertion.txt
@@ -275,6 +275,10 @@ let d
 let e
 /* back to back *//* comments */
 
+class C {
+  method/*comment*/() {}
+}
+
 b
 /* interleaved non-semi-insertion */
   .c
@@ -296,5 +300,10 @@ b
   (lexical_declaration (variable_declarator (identifier)))
   (comment)
   (comment)
+  (class_declaration (identifier) (class_body (method_definition
+    (property_identifier)
+    (comment)
+    (formal_parameters)
+    (statement_block))))
   (expression_statement
     (member_expression (identifier) (comment) (property_identifier))))

--- a/test/corpus/semicolon_insertion.txt
+++ b/test/corpus/semicolon_insertion.txt
@@ -272,6 +272,12 @@ let b /* comment between declarators */, c
 
 let d
 
+let e
+/* back to back *//* comments */
+
+b
+/* interleaved non-semi-insertion */
+  .c
 ---
 
 (program
@@ -286,4 +292,9 @@ let d
   (comment)
   (comment)
   (comment)
-  (lexical_declaration (variable_declarator (identifier))))
+  (lexical_declaration (variable_declarator (identifier)))
+  (lexical_declaration (variable_declarator (identifier)))
+  (comment)
+  (comment)
+  (expression_statement
+    (member_expression (identifier) (comment) (property_identifier))))

--- a/test/corpus/semicolon_insertion.txt
+++ b/test/corpus/semicolon_insertion.txt
@@ -276,8 +276,8 @@ let d
 
 (program
   (lexical_declaration
-    (variable_declarator (identifier)))
-  (comment)
+    (variable_declarator (identifier))
+  (comment))
   (comment)
   (lexical_declaration
     (variable_declarator (identifier))


### PR DESCRIPTION
## Problem
Today the following piece of code is valid but it is parsed incorrectly:

```javascript
class C {
  name/*comment*/() {
  }
}
```

[Here's a link to the TypeScript Playground showing that the snippet above is valid JavaScript or TypeScript:
](https://www.typescriptlang.org/play/?#code/MYGwhgzhAEDC0G8BQ1oDswFsCmB6AVMAPaY5oAu+uAFAJSIrQC+STQA)

<!-- Please run `tree-sitter parse YOUR_FILE` and show us the output. -->
The output of `tree-sitter parse` is the following:

```
program [0, 0] - [4, 0]
  class_declaration [0, 0] - [3, 1]
    name: identifier [0, 6] - [0, 7]
    body: class_body [0, 8] - [3, 1]
      member: field_definition [1, 2] - [1, 6]
        property: property_identifier [1, 2] - [1, 6]
      comment [1, 6] - [1, 17]
      member: method_definition [1, 17] - [2, 3]
        name: MISSING property_identifier [1, 17] - [1, 17]
        parameters: formal_parameters [1, 17] - [1, 19]
        body: statement_block [1, 20] - [2, 3]
```

This is because `name/*comment*/() {` was being parsed as having an automatic semicolon between `name` and `()`, but this isn't right.

This was because there was an optimization that would cause automatic semicolons to be considered valid if a comment was started. This overlooked single line block comments. 

---
## Diff summary

Turns out the problem was really nuanced:

There are two callers of `scan_whitespace_and_comments`, 
1. an optimizing caller who wants to decide that having seen a comment is enough to consider auto-semi-insertion legal.
2. another who just wants to march the lexer forward maximally.

This PR basically gives the ability for the first of these to be invoked (ie because the automatic semicolon scanner saw a comment) and _not_ result in a decision on semicolon-legality in particularly the case where only a single-line-block-comment is seen.

It does this by 
1. changing `scan_whitespace_and_comments` to have an enum return value to indicate its three results (no-decision, reject, accept)
2. giving `scan_whitespace_and_comments` a consume:false mode where it stops as soon as it pops out of (a series of) block comments

Also added tests to the corpus