### PR TITLE
Fix: allow auto-semicolon insertion before prefix-less decimal literals

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -131,7 +131,6 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
 
     switch (lexer->lookahead) {
         case ',':
-        case '.':
         case ':':
         case ';':
         case '*':
@@ -147,6 +146,11 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
         case '&':
         case '/':
             return false;
+
+        // Insert a semicolon before decimals literals but not otherwise.
+        case '.':
+            skip(lexer);
+            return iswdigit(lexer->lookahead);
 
         // Insert a semicolon before `--` and `++`, but not before binary `+` or `-`.
         case '+':

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -13,6 +13,7 @@ Numbers
 0b1_000_000
 1_2_3
 12_3.4_5e6_7
+.4_5e6_7
 0b1_000_000n
 01
 00000123
@@ -20,6 +21,7 @@ Numbers
 ---
 
 (program
+  (expression_statement (number))
   (expression_statement (number))
   (expression_statement (number))
   (expression_statement (number))


### PR DESCRIPTION
```javascript
1
.2
```

was resulting in
```
program [0, 0] - [2, 0]
  ERROR [0, 0] - [1, 1]
    number [0, 0] - [0, 1]
  expression_statement [1, 1] - [1, 2]
    number [1, 1] - [1, 2]
```

Because auto-semi-insertion was not allowed before `.`