### PR TITLE
Fix: disallow semi injection before template string

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -151,6 +151,7 @@ static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, boo
     }
 
     switch (lexer->lookahead) {
+        case '`':
         case ',':
         case ':':
         case ';':

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -64,7 +64,7 @@ Template strings
 
 `\ `;
 
-`The command \`git ${args.join(' ')}\` exited with an unexpected code: ${exitCode}. The caller should either handle this error, or expect that exit code.`
+`The command \`git ${args.join(' ')}\` exited with an unexpected code: ${exitCode}. The caller should either handle this error, or expect that exit code.`;
 
 `\\`;
 
@@ -154,10 +154,17 @@ Function calls with template strings
 ============================================
 
 f `hello`;
+f 
+`hello`;
 
 ---
 
 (program
+  (expression_statement
+    (call_expression
+      (identifier)
+      (template_string
+        (string_fragment))))
   (expression_statement
     (call_expression
       (identifier)


### PR DESCRIPTION
The following piece of code is valid but it is parsed incorrectly:

```javascript
log
`foo`;
```

The output of `tree-sitter parse` is the following:

```
program [0, 0] - [2, 0]
  expression_statement [0, 0] - [0, 3]
    identifier [0, 0] - [0, 3]
  expression_statement [1, 0] - [1, 5]
    template_string [1, 0] - [1, 5]
      string_fragment [1, 1] - [1, 4]
```

If you run a snippet like this ([playground link](https://www.typescriptlang.org/play/?filetype=js#code/MYewdgzgLgBANiA5jAvDAFADwJSoHwyiQhwCmAdAoltgFC1W0AGAZiCEwNz0DMzbHTkA))
```javascript
const log = (x) => console.log(x)

log
`foo`;

3
`foo`;
```

You'll get this output
```
[LOG]: ["foo"] 
[ERR]: "Executed JavaScript Failed:" 
[ERR]: 3 is not a function 
```

So regardless of the first expression in each clause (ie `log` or `3` ) the runtime treats `foo` as the back-half of a call expression, but tree sitter outputs the above rather than the below because of automatic semi injection.
```
(program [0, 0] - [1, 2]
  (expression_statement [0, 0] - [1, 2]
    (call_expression [0, 0] - [1, 2]
      function: (identifier [0, 0] - [0, 1])
      arguments: (template_string [1, 0] - [1, 2]))))
```

Also modified the test cases