### PR TITLE
fix: no dynamic scanner file check

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,5 @@
 // swift-tools-version:5.3
-
-import Foundation
 import PackageDescription
-
-var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
-    sources.append("src/scanner.c")
-}
 
 let package = Package(
     name: "TreeSitterJavaScript",
@@ -21,7 +14,7 @@ let package = Package(
             name: "TreeSitterJavaScript",
             dependencies: [],
             path: ".",
-            sources: sources,
+            sources: ["src/parser.c", "src/scanner.c"],
             resources: [
                 .copy("queries")
             ],


### PR DESCRIPTION
This makes it easier to build the project as a Swift package.

Mirrors the handling of scanners in other grammars like [tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash/blob/master/Package.swift#L21-L24) or [tree-sitter-html](https://github.com/tree-sitter/tree-sitter-html/blob/master/Package.swift#L17-L20).