### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,7 @@ import Foundation
 import PackageDescription
 
 var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
-    sources.append("src/scanner.c")
-}
+sources.append("src/scanner.c")
 
 let package = Package(
     name: "TreeSitterJavaScript",


### PR DESCRIPTION
re-add `src/scanner.c` that was removed in https://github.com/tree-sitter/tree-sitter-javascript/commit/be1e969d3ece0a8801061f7c2636a0d84cc32ed4

The change to not include `scanner.c` does not seems correct to me. It results in missing symbols that are needed.